### PR TITLE
Add build scripts and README file for Derecho

### DIFF
--- a/etc/derecho/README.md
+++ b/etc/derecho/README.md
@@ -37,7 +37,7 @@ cd $TUVX_HOME
 ```
 module load conda
 conda activate npl
-cd $TUVX_HOME/tuv-x-private/build
+cd $TUVX_HOME/tuv-x/build
 make test
 ```
 

--- a/etc/derecho/README.md
+++ b/etc/derecho/README.md
@@ -1,0 +1,50 @@
+# Building TUV-x on Derecho 
+
+## Get the source code
+
+- Copy the build script you wish to use from this folder to GLADE.
+  There are scripts for GNU and Intel compilers, without MPI support.
+
+- Log in to Derecho
+
+- Create a directory to build TUV-x in:
+
+```
+mkdir my-tuvx-build
+```
+
+- Create an environment variable named `TUVX_HOME` pointing to the absolute path of your build directory:
+
+```
+export TUVX_HOME=/path/to/my-tuvx-build
+```
+
+## Build TUV-x
+
+Replace `/path/to/build_tuvx_derecho_X.sh` with the path to the build script you copied to GLADE, in the following:
+
+```
+cd $TUVX_HOME
+. /path/to/build_tuvx_derecho_X.sh
+```
+
+## Run TUV-x
+- Whenever you go to run TUV-x after it has been built, make sure you have the correct environment modules loaded.
+  Look at the top of the build script you used to find the modules required.
+
+- Run a test. The tests use the python numpy package, and we access this through the conda environment module on Derecho:
+
+```
+module load conda
+conda activate npl
+cd $TUVX_HOME/tuv-x-private/build
+make test
+```
+
+- Run a configuration (this does not require any Python packages)
+
+```
+cd $TUVX_HOME/tuv-x-private/build
+./tuv-x examples/full_config.json
+```
+

--- a/etc/derecho/README.md
+++ b/etc/derecho/README.md
@@ -44,7 +44,7 @@ make test
 - Run a configuration (this does not require any Python packages)
 
 ```
-cd $TUVX_HOME/tuv-x-private/build
+cd $TUVX_HOME/tuv-x/build
 ./tuv-x examples/full_config.json
 ```
 

--- a/etc/derecho/build_tuvx_derecho_gnu.sh
+++ b/etc/derecho/build_tuvx_derecho_gnu.sh
@@ -42,8 +42,8 @@ echo "Building TUV-x"
 # get & build the source code of TUV-x
 
 cd ${TUVX_HOME}
-git clone git@github.com:NCAR/tuv-x-private.git
-cd tuv-x-private
+git clone git@github.com:NCAR/tuv-x.git
+cd tuv-x
 mkdir build
 cd build
 export JSON_FORTRAN_HOME=$INSTALL_DIR/jsonfortran-gnu-8.3.0

--- a/etc/derecho/build_tuvx_derecho_gnu.sh
+++ b/etc/derecho/build_tuvx_derecho_gnu.sh
@@ -1,0 +1,51 @@
+# Downloads and builds TUV-x and its dependencies on Derecho using GNU compilers
+#
+# The TUVX_HOME environment variable must be set to the directory to build TUV-x
+# in prior to calling this script
+
+
+module purge
+module load ncarenv/23.09
+module load craype/2.7.20
+module load gcc/12.2.0
+module load cray-libsci/23.02.1.1
+module load netcdf/4.9.2
+module load ncarcompilers/1.0.0
+module load cmake/3.26.3
+
+if [[ -z "${TUVX_HOME}" ]]; then
+  echo "You must set the TUVX_HOME environment variable to the directory where TUV-x should be build."
+  return
+fi
+
+if [[ ! -d "${TUVX_HOME}" ]]; then
+  echo "TUVX_HOME must point to an existing directory"
+  return
+fi
+
+echo "Building JSON Fortran"
+
+# get & build the source code of JSON Fortran
+
+cd ${TUVX_HOME}
+curl -LO https://github.com/jacobwilliams/json-fortran/archive/8.3.0.tar.gz
+tar -zxvf 8.3.0.tar.gz
+cd json-fortran-8.3.0
+mkdir build
+cd build
+INSTALL_DIR=$TUVX_HOME/json-fortran-8.3.0
+cmake -D SKIP_DOC_GEN:BOOL=TRUE -D CMAKE_INSTALL_PREFIX=$INSTALL_DIR ..
+make install
+
+echo "Building TUV-x"
+
+# get & build the source code of TUV-x
+
+cd ${TUVX_HOME}
+git clone git@github.com:NCAR/tuv-x-private.git
+cd tuv-x-private
+mkdir build
+cd build
+export JSON_FORTRAN_HOME=$INSTALL_DIR/jsonfortran-gnu-8.3.0
+cmake -D CMAKE_BUILD_TYPE=release -D ENABLE_MEMCHECK=OFF -D LAPACK_LIBRARIES=-lsci_gnu ..   
+make -j 8

--- a/etc/derecho/build_tuvx_derecho_intel.sh
+++ b/etc/derecho/build_tuvx_derecho_intel.sh
@@ -1,0 +1,49 @@
+# Downloads and builds TUV-x and its dependencies on Derecho using Intel compilers
+#
+# The TUVX_HOME environment variable must be set to the directory to build TUV-x
+# in prior to calling this script
+
+module purge
+module load ncarenv/23.09
+module load intel/2023.2.1
+module load netcdf/4.9.2
+module load mkl/2023.2.0
+module load ncarcompilers/1.0.0
+module load cmake/3.26.3
+
+if [[ -z "${TUVX_HOME}" ]]; then
+  echo "You must set the TUVX_HOME environment variable to the directory where TUV-x should be build."
+  return
+fi
+
+if [[ ! -d "${TUVX_HOME}" ]]; then
+  echo "TUVX_HOME must point to an existing directory"
+  return
+fi
+
+echo "Building JSON Fortran"
+
+# get & build the source code of JSON Fortran
+
+cd ${TUVX_HOME}
+curl -LO https://github.com/jacobwilliams/json-fortran/archive/8.3.0.tar.gz
+tar -zxvf 8.3.0.tar.gz
+cd json-fortran-8.3.0
+mkdir build
+cd build
+INSTALL_DIR=$TUVX_HOME/json-fortran-8.3.0
+cmake -D SKIP_DOC_GEN:BOOL=TRUE -D CMAKE_INSTALL_PREFIX=$INSTALL_DIR ..
+make install
+
+echo "Building TUV-x"
+
+# get & build the source code of TUV-x
+
+cd ${TUVX_HOME}
+git clone git@github.com:NCAR/tuv-x-private.git
+cd tuv-x-private
+mkdir build
+cd build
+export JSON_FORTRAN_HOME=$INSTALL_DIR/jsonfortran-intel-8.3.0
+cmake -D CMAKE_BUILD_TYPE=release -D ENABLE_MEMCHECK=OFF -DBLAS_LIBRARIES=-lmkl_rt -DLAPACK_LIBRARIES=-lmkl_rt ..
+make -j 8

--- a/etc/derecho/build_tuvx_derecho_intel.sh
+++ b/etc/derecho/build_tuvx_derecho_intel.sh
@@ -40,8 +40,8 @@ echo "Building TUV-x"
 # get & build the source code of TUV-x
 
 cd ${TUVX_HOME}
-git clone git@github.com:NCAR/tuv-x-private.git
-cd tuv-x-private
+git clone git@github.com:NCAR/tuv-x.git
+cd tuv-x
 mkdir build
 cd build
 export JSON_FORTRAN_HOME=$INSTALL_DIR/jsonfortran-intel-8.3.0


### PR DESCRIPTION
This PR introduces the build scripts and README file about how to build TUV-x and its dependencies on Derecho.

The scripts work for both GNU and Intel compilers (both of them compile successfully).

- Using the GNU compiler, all the 59 regression tests are passed.
- Using the Intel compiler, the regression test suite hangs at the regression_aerosols_radiator_4strm test for an unknown reason (https://github.com/NCAR/tuv-x-private/issues/286).