### PR TITLE
add TS1 and TSMLT configuration to examples

### DIFF
--- a/data/dose_rates.json
+++ b/data/dose_rates.json
@@ -1,4 +1,7 @@
-   "__description": "This file contains all the dose rates that can be calculated using data in this folder",
+   "__description": [
+     "This file contains all the dose rates that can be calculated using data in this folder",
+     "The original TUV 5.4 source code and data sets can be found here: https://www2.acom.ucar.edu/modeling/tuv-download"
+   ],
    "dose rates": {
       "enable diagnostics": true,
       "rates": [

--- a/data/photolysis_rate_constants.json
+++ b/data/photolysis_rate_constants.json
@@ -1,4 +1,7 @@
-    "__description": "This file contains configurations for each of the photolysis rate constants that can be calculated using data from this folder",
+    "__description": [
+      "This file contains configurations for each of the TUV 5.4 photolysis rate constants that can be calculated using data from this folder",
+      "The original TUV 5.4 source code and data sets can be found here: https://www2.acom.ucar.edu/modeling/tuv-download"
+    ],
    "photolysis": {
       "enable diagnostics" : true,
       "reactions": [

--- a/examples/ts1_tsmlt.json
+++ b/examples/ts1_tsmlt.json
@@ -1,0 +1,1592 @@
+{
+   "__description": "TUV-x configuration for the MOZART-TS1 and MOZART-TSMLT chemical mechanisms",
+   "O2 absorption" : {
+     "cross section parameters file": "data/cross_sections/O2_parameters.txt"
+   },
+   "grids": [
+      {
+         "name": "height",
+         "type": "equal interval",
+         "units": "km",
+         "begins at" : 0.0,
+         "ends at" : 120.0,
+         "cell delta" : 1.0
+      },
+      {
+         "name": "wavelength",
+         "type": "from csv file",
+         "units": "nm",
+         "file path": "data/grids/wavelength/combined.grid"
+      },
+      {
+         "name": "time",
+         "type": "from config file",
+         "units": "hours",
+         "values": [ 12.0, 14.0 ]
+      }
+   ],
+   "profiles": [
+      {
+         "name": "O3",
+         "type": "O3",
+         "units": "molecule cm-3",
+         "file path": "data/profiles/atmosphere/ussa.ozone"
+      },
+      {
+         "name": "air",
+         "type": "air",
+         "units": "molecule cm-3",
+         "file path": "data/profiles/atmosphere/ussa.dens"
+      },
+      {
+         "name": "O2",
+         "type": "O2",
+         "units": "molecule cm-3",
+         "file path": "data/profiles/atmosphere/ussa.dens"
+      },
+      {
+         "name": "temperature",
+         "type": "from csv file",
+         "units": "K",
+         "file path": "data/profiles/atmosphere/ussa.temp",
+         "grid": {
+           "name": "height",
+           "units": "km"
+         }
+      },
+      {
+         "name": "solar zenith angle",
+         "type": "solar zenith angle",
+         "units": "degrees",
+         "year" : 2002,
+         "month": 3,
+         "day": 21,
+         "longitude": 0.0,
+         "latitude": 0.0
+      },
+      {
+         "name": "Earth-Sun distance",
+         "type": "Earth-Sun distance",
+         "units": "AU",
+         "year" : 2002,
+         "month": 3,
+         "day": 21
+      },
+      {
+         "name": "surface albedo",
+         "type": "from config file",
+         "units": "none",
+         "uniform value": 0.10,
+         "grid": {
+           "name": "wavelength",
+           "units": "nm"
+         }
+      },
+      {
+         "name": "extraterrestrial flux",
+         "enable diagnostics" : true,
+         "type": "extraterrestrial flux",
+         "units": "photon cm-2 s-1",
+         "file path": ["data/profiles/solar/susim_hi.flx",
+                      "data/profiles/solar/atlas3_1994_317_a.dat",
+                      "data/profiles/solar/sao2010.solref.converted",
+                      "data/profiles/solar/neckel.flx"],
+         "interpolator": ["","","","fractional target"]
+      }
+   ],
+   "radiative transfer": {
+      "__output": true,
+      "solver" : {
+         "type" : "delta eddington"
+      },
+      "cross sections": [
+         {
+            "name": "air",
+            "type": "air"
+         },
+         {
+            "name": "O3",
+            "netcdf files": [
+              { "file path": "data/cross_sections/O3_1.nc" },
+              { "file path": "data/cross_sections/O3_2.nc" },
+              { "file path": "data/cross_sections/O3_3.nc" },
+              { "file path": "data/cross_sections/O3_4.nc" }
+            ],
+            "type": "O3"
+         },
+         {
+            "name": "O2",
+            "netcdf files": [
+              {
+                "file path": "data/cross_sections/O2_1.nc",
+                "lower extrapolation": { "type": "boundary" }
+              }
+            ],
+            "type": "base"
+         }
+      ],
+      "radiators": [
+         {
+            "enable diagnostics" : true,
+            "name": "air",
+            "type": "base",
+            "treat as air": true,
+            "cross section": "air",
+            "vertical profile": "air",
+            "vertical profile units": "molecule cm-3"
+         },
+         {
+            "enable diagnostics" : true,
+            "name": "O2",
+            "type": "base",
+            "cross section": "O2",
+            "vertical profile": "O2",
+            "vertical profile units": "molecule cm-3"
+         },
+         {
+            "enable diagnostics" : true,
+            "name": "O3",
+            "type": "base",
+            "cross section": "O3",
+            "vertical profile": "O3",
+            "vertical profile units": "molecule cm-3"
+         },
+         {
+            "enable diagnostics" : true,
+            "name": "aerosols",
+            "type": "aerosol",
+            "optical depths": [2.40e-01, 1.06e-01, 4.56e-02, 1.91e-02, 1.01e-02, 7.63e-03,
+                               5.38e-03, 5.00e-03, 5.15e-03, 4.94e-03, 4.82e-03, 4.51e-03,
+                               4.74e-03, 4.37e-03, 4.28e-03, 4.03e-03, 3.83e-03, 3.78e-03,
+                               3.88e-03, 3.08e-03, 2.26e-03, 1.64e-03, 1.23e-03, 9.45e-04,
+                               7.49e-04, 6.30e-04, 5.50e-04, 4.21e-04, 3.22e-04, 2.48e-04,
+                               1.90e-04, 1.45e-04, 1.11e-04, 8.51e-05, 6.52e-05, 5.00e-05,
+                               3.83e-05, 2.93e-05, 2.25e-05, 1.72e-05, 1.32e-05, 1.01e-05,
+                               7.72e-06, 5.91e-06, 4.53e-06, 3.46e-06, 2.66e-06, 2.04e-06,
+                               1.56e-06, 1.19e-06, 9.14e-07],
+            "single scattering albedo": 0.99,
+            "asymmetry factor": 0.61,
+            "550 nm optical depth": 0.235
+         }
+      ]
+   },
+   "photolysis": {
+      "reactions": [
+         {
+            "name": "jo2_a",
+            "__reaction": "O2 + hv -> O + O1D",
+            "cross section": {
+              "netcdf files": [
+                {
+                   "file path": "data/cross_sections/O2_1.nc",
+                   "lower extrapolation": { "type": "boundary" },
+                   "interpolator": { "type": "fractional target" }
+                 }
+               ],
+               "type": "base"
+            },
+            "quantum yield": {
+              "type": "base",
+              "constant value": 0,
+              "override bands": [
+                {
+                  "band": "lyman-alpha",
+                  "value": 0.53
+                },
+                {
+                  "band": "schumann-runge continuum",
+                  "value": 1.0
+                }
+              ]
+            }
+         },
+         {
+            "name": "jo2_b",
+            "__reaction": "O2 + hv -> O + O",
+            "cross section": {
+               "netcdf files": [
+                 {
+                   "file path": "data/cross_sections/O2_1.nc",
+                   "lower extrapolation": { "type": "boundary" },
+                   "interpolator": { "type": "fractional target" }
+                 }
+               ],
+               "type": "base"
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 1.0,
+               "override bands": [
+                 {
+                   "band": "lyman-alpha",
+                   "value": 0.47
+                 },
+                 {
+                   "band": "schumann-runge continuum",
+                   "value": 0.0
+                 }
+               ]
+            }
+         },
+         {
+            "name": "jo3_a",
+            "__reaction": "O3 + hv -> O2 + O(1D)",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/O3_1.nc" },
+                 { "file path": "data/cross_sections/O3_2.nc" },
+                 { "file path": "data/cross_sections/O3_3.nc" },
+                 { "file path": "data/cross_sections/O3_4.nc" }
+               ],
+               "type": "O3"
+            },
+            "quantum yield": {
+               "type": "O3+hv->O2+O(1D)"
+            }
+         },
+         {
+            "name": "jo3_b",
+            "__reaction": "O3 + hv -> O2 + O(3P)",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/O3_1.nc" },
+                 { "file path": "data/cross_sections/O3_2.nc" },
+                 { "file path": "data/cross_sections/O3_3.nc" },
+                 { "file path": "data/cross_sections/O3_4.nc" }
+               ],
+               "type": "O3"
+            },
+            "quantum yield": {
+               "type": "O3+hv->O2+O(3P)"
+            }
+         },
+         {
+            "name": "jn2o",
+            "__reaction": "N2O + hv -> N2 + O(1D)",
+            "cross section": {
+               "type": "N2O+hv->N2+O(1D)"
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 1.0
+            }
+         },
+         {
+            "name": "jno2",
+            "__reaction": "NO2 + hv -> NO + O(3P)",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/NO2_1.nc" }
+               ],
+               "type": "NO2 tint"
+            },
+            "quantum yield": {
+               "netcdf files": ["data/quantum_yields/NO2_1.nc"],
+               "type": "NO2 tint",
+               "lower extrapolation": { "type": "boundary" }
+            }
+         },
+         {
+            "name": "jn2o5_a",
+            "__reaction": "N2O5 + hv -> NO2 + NO3",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/N2O5_1.nc" },
+                 { "file path": "data/cross_sections/N2O5_2.nc" }
+               ],
+               "type": "N2O5+hv->NO2+NO3"
+            },
+            "quantum yield": {
+               "type": "base",
+               "netcdf files": [ "data/quantum_yields/N2O5_NO3_NO2.nc" ]
+            }
+         },
+         {
+            "name": "jn2o5_b",
+            "__reaction": "N2O5 + hv -> NO + O + NO3",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/N2O5_1.nc" },
+                 { "file path": "data/cross_sections/N2O5_2.nc" }
+               ],
+               "type": "N2O5+hv->NO2+NO3"
+            },
+            "quantum yield": {
+               "type": "base",
+               "netcdf files": [ "data/quantum_yields/N2O5_NO3_NO_O.nc" ]
+            }
+         },
+         {
+            "name": "jhno3",
+            "__reaction": "HNO3 + hv -> OH + NO2",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/HNO3_1.nc" }
+               ],
+               "type": "HNO3+hv->OH+NO2"
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 1.0
+            }
+         },
+         {
+            "name": "jno3_a",
+            "__reaction": "NO3 + hv -> NO2 + O(3P)",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/NO3_1.nc" }
+               ],
+               "type": "base"
+            },
+            "quantum yield": {
+               "netcdf files": [
+                  "data/quantum_yields/NO3-NO2+O(3P)_1.nc"
+               ],
+               "type": "tint",
+               "lower extrapolation": {
+                  "type": "constant",
+                  "value": 1.0
+               }
+            }
+         },
+         {
+            "name": "jno3_b",
+            "__reaction": "NO3 + hv -> NO + O2",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/NO3_1.nc" }
+               ],
+               "type": "base"
+            },
+            "quantum yield": {
+               "netcdf files": [
+                  "data/quantum_yields/NO3-NO+O2_1.nc"
+               ],
+               "type": "tint"
+            }
+         },
+         {
+            "name": "jch3ooh",
+            "__reaction": "CH3OOH + hv -> CH3O + OH",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/CH3OOH_1.nc" }
+               ],
+               "type": "base"
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 1.0
+            }
+         },
+         {
+            "name": "jch2o_a",
+            "__reaction": "CH2O + hv -> H + HCO",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/CH2O_1.nc" }
+               ],
+               "type": "CH2O"
+            },
+            "quantum yield": {
+               "netcdf files": [
+                  "data/quantum_yields/CH2O_1.nc"
+               ],
+               "type": "base",
+               "lower extrapolation": {
+                  "type": "boundary"
+               }
+            }
+         },
+         {
+            "name": "jch2o_b",
+            "__reaction": "CH2O + hv -> H2 + CO",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/CH2O_1.nc" }
+               ],
+               "type": "CH2O"
+            },
+            "quantum yield": {
+               "netcdf files": [
+                  "data/quantum_yields/CH2O_1.nc"
+               ],
+               "type": "CH2O",
+               "lower extrapolation": {
+                  "type": "boundary"
+               }
+            }
+         },
+         {
+            "name": "jh2o2",
+            "__reaction": "H2O2 + hv -> OH + OH",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/H2O2_1.nc" }
+               ],
+               "type": "H2O2+hv->OH+OH"
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 1.0
+            }
+         },
+         {
+            "name": "jch3cho",
+            "__reaction": "CH3CHO + hv -> CH3 + HCO",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/CH3CHO_1.nc" }
+               ],
+               "type": "base"
+            },
+            "quantum yield": {
+               "netcdf files": [
+                  "data/quantum_yields/CH3CHO_1.nc"
+               ],
+               "type": "CH3CHO+hv->CH3+HCO"
+            }
+         },
+         {
+            "name": "jpan",
+            "__reaction": "PAN + hv -> 0.6*CH3CO3 + 0.6*NO2 + 0.4*CH3O2 + 0.4*NO3 + 0.4*CO2",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/PAN_1.nc" }
+               ],
+               "type": "CH3ONO2+hv->CH3O+NO2"
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 1.0
+            }
+         },
+         {
+            "name": "jmvk",
+            "__reaction": "MVK + hv -> 0.7*C3H6 + 0.7*CO + 0.3*CH3O2 + 0.3*CH3CO3",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/MVK_1.nc" }
+               ],
+               "type": "base"
+            },
+            "quantum yield": {
+               "type": "MVK+hv->Products"
+            }
+         },
+         {
+            "name": "jacet",
+            "__reaction": "CH3COCH3 + hv -> CH3CO + CH3",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/CH3COCH3_1.nc" }
+               ],
+               "type": "CH3COCH3+hv->CH3CO+CH3"
+            },
+            "quantum yield": {
+               "type": "CH3COCH3+hv->CH3CO+CH3"
+            }
+         },
+         {
+            "name": "jmgly",
+            "__reaction": "CH3COCHO + hv -> CH3CO3 + CO + HO2",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/CH3COCHO_1.nc" }
+               ],
+               "type": "base"
+            },
+            "quantum yield": {
+               "type": "CH3COCHO+hv->CH3CO+HCO"
+            }
+         },
+         {
+            "name": "jglyald",
+            "__reaction": "GLYALD + hv -> 2*HO2 + CO + CH2O",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/HOCH2CHO_1.nc" }
+               ],
+               "type": "base"
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 0.5
+            }
+         },
+         {
+            "name": "jglyoxal",
+            "__reaction": "GLYOXAL + hv -> 2*CO + 2*HO2",
+            "__comments": "TODO the products of this reaction don't exactly match",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/CHOCHO_1.nc" }
+               ],
+               "type": "base"
+            },
+            "quantum yield": {
+               "netcdf files": [
+                  "data/quantum_yields/CHOCHO-H2_CO_CO_1.nc"
+               ],
+               "type": "base",
+               "lower extrapolation": {
+                  "type": "boundary"
+               }
+            }
+         },
+         {
+            "name": "jbrcl",
+            "__reaction": "BrCl + hv -> Br + Cl",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/BrCl_1.nc" }
+               ],
+               "type": "base"
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 1.0
+            }
+         },
+         {
+            "name": "jbro",
+            "__reaction": "BrO + hv -> Br + O",
+            "cross section": {
+               "netcdf files": [
+                 {
+                   "file path": "data/cross_sections/BrO_1.nc",
+                   "interpolator": {
+                      "type": "fractional target",
+                      "fold in": true
+                   }
+                 }
+               ],
+               "type": "base"
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 1.0
+            }
+         },
+         {
+            "name": "jbrono2_a",
+            "__reaction": "BrONO2 + hv -> Br + NO3",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/BrONO2_1.nc" }
+               ],
+               "type": "base"
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 0.85
+            }
+         },
+         {
+            "name": "jbrono2_b",
+            "__reaction": "BrONO2 + hv -> BrO + NO2",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/BrONO2_1.nc" }
+               ],
+               "type": "base"
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 0.15
+            }
+         },
+         {
+            "name": "jccl4",
+            "__reaction": "CCl4 + hv -> Products",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/CCl4_1.nc" }
+               ],
+               "type": "CCl4+hv->Products"
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 1.0
+            }
+         },
+         {
+            "name": "jcf2clbr",
+            "__reaction": "CF2BrCl + hv -> Products",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/CF2BrCl_1.nc" }
+               ],
+               "type": "base"
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 1.0
+            }
+         },
+         {
+            "name": "jcf3br",
+            "__reaction": "CF3Br + hv -> Products",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/CF3Br_1.nc" }
+               ],
+               "type": "base"
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 1.0
+            }
+         },
+         {
+            "name": "jcfcl3",
+            "__reaction": "CCl3F + hv -> Products",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/CFC-11_1.nc" }
+               ],
+               "type": "CCl3F+hv->Products"
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 1.0
+            }
+         },
+         {
+            "name": "jcfc113",
+            "__reaction": "CFC-113 + hv -> Products",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/CFC-113_1.nc" }
+               ],
+               "type": "tint"
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 1.0
+            }
+         },
+         {
+            "name": "jcfc114",
+            "__reaction": "CFC-114 + hv -> Products",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/CFC-114_1.nc" }
+               ],
+               "type": "tint"
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 1.0
+            }
+         },
+         {
+            "name": "jcfc115",
+            "__reaction": "CFC-115 + hv -> Products",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/CFC-115_1.nc" }
+               ],
+               "type": "base"
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 1.0
+            }
+         },
+         {
+            "name": "jcf2cl2",
+            "__reaction": "CCl2F2 + hv -> Products",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/CFC-12_1.nc" }
+               ],
+               "type": "CCl3F+hv->Products"
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 1.0
+            }
+         },
+         {
+            "name": "jch2br2",
+            "__reaction": "CH2BR2 + hv -> 2*BR",
+            "cross section": {
+               "type": "temperature based",
+               "netcdf file": "data/cross_sections/CH2BR2_1.nc",
+               "parameterization": {
+                  "AA": [ -70.211776,  1.940326e-1, 2.726152e-3, -1.695472e-5, 2.500066e-8  ],
+                  "BB": [   2.899280, -4.327724e-2, 2.391599e-4, -5.807506e-7, 5.244883e-10 ],
+                  "lp": [        0.0,          1.0,          2.0,         3.0,          4.0 ],
+                  "minimum wavelength": 210.0,
+                  "maximum wavelength": 290.0,
+                  "temperature ranges": [
+                     {
+                        "maximum": 209.999999999999,
+                        "fixed value": 210.0
+                     },
+                     {
+                        "minimum": 210,
+                        "maximum": 300
+                     },
+                     {
+                        "minimum": 300.00000000001,
+                        "fixed value": 300.0
+                     }
+                  ]
+               }
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 1.0
+            }
+         },
+         {
+            "name": "jch3br",
+            "__reaction": "CH3Br + hv -> Products",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/CH3Br_1.nc" }
+               ],
+               "type": "base"
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 1.0
+            }
+         },
+         {
+            "name": "jch3ccl3",
+            "__reaction": "CH3CCl3+hv->Products",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/CH3CCl3_1.nc" }
+               ],
+               "type": "tint"
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 1.0
+            }
+         },
+         {
+            "name": "jch3cl",
+            "__reaction": "CH3Cl + hv -> Products",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/CH3Cl_1.nc" }
+               ],
+               "type": "tint"
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 1.0
+            }
+         },
+         {
+            "name": "jchbr3",
+            "__reaction": "CHBr3 + hv -> Products",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/CHBr3_1.nc" }
+               ],
+               "type": "CHBr3+hv->Products",
+               "lower extrapolation": {
+                  "type": "boundary"
+               }
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 1.0
+            }
+         },
+         {
+            "name": "jcl2",
+            "__reaction": "Cl2 + hv -> Cl + Cl",
+            "cross section": {
+               "type": "Cl2+hv->Cl+Cl"
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 1.0
+            }
+         },
+         {
+            "name": "jcl2o2",
+            "__reaction": "ClOOCl + hv -> Cl + ClOO",
+            "__comments": "TODO - this doesn't exactly match the products in TS1",
+            "cross section": {
+               "netcdf files": [
+                  { "file path": "data/cross_sections/ClOOCl_1.nc" }
+               ],
+               "type": "base"
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 1.0
+            }
+         },
+         {
+            "name": "jclo",
+            "__reaction": "ClO + hv -> Cl + O(1D)",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/ClO_1.nc" }
+               ],
+               "type": "tint"
+            },
+            "quantum yield": {
+               "type": "ClO+hv->Cl+O(1D)"
+            }
+         },
+         {
+            "name": "jclono2_a",
+            "__reaction": "ClONO2 + hv -> Cl + NO3",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/ClONO2_1.nc" }
+               ],
+               "type": "ClONO2"
+            },
+            "quantum yield": {
+               "type": "ClONO2+hv->Cl+NO3"
+            }
+         },
+         {
+            "name": "jclono2_b",
+            "__reaction": "ClONO2 + hv -> ClO + NO2",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/ClONO2_1.nc" }
+               ],
+               "type": "ClONO2"
+            },
+            "quantum yield": {
+               "type": "ClONO2+hv->ClO+NO2"
+            }
+         },
+         {
+            "name": "jcof2",
+            "__reaction": "CF2O + hv -> Products",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/CF2O_1.nc" }
+               ],
+               "type": "base"
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 1.0
+            }
+         },
+         {
+            "name": "jcofcl",
+            "__reaction": "CClFO + hv -> Products",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/CClFO_1.nc" }
+               ],
+               "type": "base"
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 1.0
+            }
+         },
+         {
+            "name": "jh2402",
+            "__reaction": "H2402 + hv -> 2*BR + 2*COF2",
+            "__comments": "TUV data set name CF2BrCF2Br",
+            "cross section": {
+               "netcdf files": [
+                  { "file path": "data/cross_sections/CF2BrCF2Br_1.nc" }
+               ],
+               "type": "base"
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 1.0
+            }
+         },
+         {
+            "name": "jhcfc141b",
+            "__reaction": "HCFC-141b + hv -> Products",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/CH3CFCl2_1.nc" }
+               ],
+               "type": "base"
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 1.0
+            }
+         },
+         {
+            "name": "jhcfc142b",
+            "__reaction": "HCFC-142b + hv -> Products",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/CH3CF2Cl_1.nc" }
+               ],
+               "type": "HCFC+hv->Products"
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 1.0
+            }
+         },
+         {
+            "name": "jhcfc22",
+            "__reaction": "HCFC-22 + hv -> Products",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/CHClF2_1.nc" }
+               ],
+               "type": "tint"
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 1.0
+            }
+         },
+         {
+            "name": "jhcl",
+            "__reaction": "HCl + hv -> H + Cl",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/HCl_1.nc" }
+               ],
+               "type": "base"
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 1.0
+            }
+         },
+         {
+            "name": "jhobr",
+            "__reaction": "HOBr + hv -> OH + Br",
+            "cross section": {
+               "type": "HOBr+hv->OH+Br"
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 1.0
+            }
+         },
+         {
+            "name": "jhocl",
+            "__reaction": "HOCl + hv -> HO + Cl",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/HOCl_1.nc" }
+               ],
+               "type": "base"
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 1.0
+            }
+         },
+         {
+            "name": "joclo",
+            "__reaction": "OClO + hv -> Products",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/OClO_1.nc" },
+                 { "file path": "data/cross_sections/OClO_2.nc" },
+                 { "file path": "data/cross_sections/OClO_3.nc" }
+               ],
+               "type": "OClO+hv->Products"
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 1.0
+            }
+         },
+         {
+            "name": "jho2no2_a",
+            "__reaction": "HNO4 + hv -> OH + NO3",
+            "__comments": "TODO Doug's data sets have special temperature dependence - need new type?",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/HNO4_1.nc" }
+               ],
+               "type": "base"
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 0.2
+            }
+         },
+         {
+            "name": "jho2no2_b",
+            "__reaction": "HNO4 + hv -> HO2 + NO2",
+            "__comments": "TODO Doug's data sets have special temperature dependence - need new type?",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/HNO4_1.nc" }
+               ],
+               "type": "base"
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 0.8
+            }
+         },
+         {
+            "name": "jmacr_a",
+            "__reaction": "CH2=C(CH3)CHO->1.34HO2+0.66MCO3+1.34CH2O+CH3CO3",
+            "__comments": "Methacrolein photolysis channel 1",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/Methacrolein_1.nc" }
+               ],
+               "type": "base"
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 0.005
+            }
+         },
+         {
+            "name": "jmacr_b",
+            "__reaction": "CH2=C(CH3)CHO->0.66OH+1.34CO",
+            "__comments": "Methacrolein photolysis channel 2",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/Methacrolein_1.nc" }
+               ],
+               "type": "base"
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 0.005
+            }
+         },
+         {
+            "name": "jhyac",
+            "__reaction": "CH2(OH)COCH3->CH3CO3+HO2+CH2O",
+            "__comments": "hydroxy acetone TODO: the products of this reaction differ from standalone TUV-x",
+            "cross section": {
+               "netcdf files": [
+                 { "file path": "data/cross_sections/Hydroxyacetone_1.nc" }
+               ],
+               "type": "base"
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 0.65
+            }
+         },
+         {
+            "name": "jh2o_a",
+            "__reaction": "H2O + hv -> OH + H",
+            "cross section": {
+               "type": "base",
+               "merge data": true,
+               "netcdf files": [
+                  {
+                     "file path": "data/cross_sections/H2O_1.nc",
+                     "zero above": 183.0
+                  },
+                  {
+                     "file path": "data/cross_sections/H2O_2.nc",
+                     "zero below": 183.00000000001,
+                     "zero above": 190.0
+                  },
+                  {
+                     "file path": "data/cross_sections/H2O_3.nc",
+                     "zero below": 190.00000000001
+                  }
+               ]
+            },
+            "quantum yield" : {
+               "type": "base",
+               "netcdf files": [ "data/quantum_yields/H2O_H_OH.nc" ]
+            }
+         },
+         {
+            "name": "jh2o_b",
+            "__reaction": "H2O + hv -> H2 + O1D",
+            "cross section": {
+               "type": "base",
+               "merge data": true,
+               "netcdf files": [
+                  {
+                     "file path": "data/cross_sections/H2O_1.nc",
+                     "zero above": 183.0
+                  },
+                  {
+                     "file path": "data/cross_sections/H2O_2.nc",
+                     "zero below": 183.00000000001,
+                     "zero above": 190.0
+                  },
+                  {
+                     "file path": "data/cross_sections/H2O_3.nc",
+                     "zero below": 190.00000000001
+                  }
+               ]
+            },
+            "quantum yield" : {
+               "type": "base",
+               "netcdf files": [ "data/quantum_yields/H2O_H2_O1D.nc" ]
+            }
+         },
+         {
+            "name": "jh2o_c",
+            "__reaction": "H2O + hv -> 2*H + O",
+            "cross section": {
+               "type": "base",
+               "merge data": true,
+               "netcdf files": [
+                  {
+                     "file path": "data/cross_sections/H2O_1.nc",
+                     "zero above": 183.0
+                  },
+                  {
+                     "file path": "data/cross_sections/H2O_2.nc",
+                     "zero below": 183.00000000001,
+                     "zero above": 190.0
+                  },
+                  {
+                     "file path": "data/cross_sections/H2O_3.nc",
+                     "zero below": 190.00000000001
+                  }
+               ]
+            },
+            "quantum yield" : {
+               "type": "base",
+               "netcdf files": [ "data/quantum_yields/H2O_2H_O3P.nc" ]
+            }
+         },
+         {
+            "name": "jch4_a",
+            "__reaction": "CH4 + hv -> H + CH3O2",
+            "cross section": {
+               "type": "base",
+               "netcdf files": [
+                  { "file path": "data/cross_sections/CH4_1.nc" }
+               ]
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 0.55
+            }
+         },
+         {
+            "name": "jch4_b",
+            "__reaction": "CH4 + hv -> 1.44*H2 + 0.18*CH2O + 0.18*O + 0.33*OH + 0.33*H + 0.44*CO2 + 0.38*CO + 0.05*H2O",
+            "cross section": {
+               "type": "base",
+               "netcdf files": [
+                  { "file path": "data/cross_sections/CH4_1.nc" }
+               ]
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 0.45
+            }
+         },
+         {
+            "name": "jco2",
+            "__reaction": "CO2 + hv -> CO + O",
+            "cross section": {
+               "type": "base",
+               "netcdf files": [
+                  { "file path": "data/cross_sections/CO2_1.nc" }
+               ]
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 1.0
+            }
+         },
+         {
+            "name": "jhbr",
+            "__reaction": "HBR + hv -> BR + H",
+            "cross section": {
+               "type": "base",
+               "netcdf files": [
+                  { "file path": "data/cross_sections/HBr_1.nc" }
+               ]
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 1.0
+            }
+         },
+         {
+            "name": "jhf",
+            "__reaction": "HF + hv -> H + F",
+            "cross section": {
+               "type": "base",
+               "netcdf files": [
+                  { "file path": "data/cross_sections/HF_1.nc" }
+               ]
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 1.0
+            }
+         },
+         {
+            "name": "jsf6",
+            "__reaction": "SF6 + hv -> sink",
+            "cross section": {
+               "type": "base",
+               "netcdf files": [
+                  { "file path": "data/cross_sections/SF6_1.nc" }
+               ]
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 1.0
+            }
+         },
+         {
+            "name": "jh2so4",
+            "__reaction": "H2SO4 + hv -> SO3 + H2O",
+            "cross section": {
+               "type": "base",
+               "netcdf files": [
+                  { "file path": "data/cross_sections/H2SO4_1.nc" }
+               ]
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 1.0
+            }
+         },
+         {
+            "name": "jocs",
+            "__reaction": "OCS + hv -> S + CO",
+            "cross section": {
+               "type": "base",
+               "netcdf files": [
+                  { "file path": "data/cross_sections/OCS_1.nc" }
+               ]
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 1.0
+            }
+         },
+         {
+            "name": "jso",
+            "__reaction": "SO + hv -> S + O",
+            "cross section": {
+               "type": "base",
+               "netcdf files": [
+                  { "file path": "data/cross_sections/SO_1.nc" }
+               ]
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 1.0
+            }
+         },
+         {
+            "name": "jso2",
+            "__reaction": "SO2 + hv -> SO + O",
+            "cross section": {
+               "type": "base",
+               "netcdf files": [
+                  { "file path": "data/cross_sections/SO2_1.nc" }
+               ]
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 1.0
+            }
+         },
+         {
+            "name": "jso3",
+            "__reaction": "SO3 + hv -> SO2 + O",
+            "cross section": {
+               "type": "base",
+               "netcdf files": [
+                  { "file path": "data/cross_sections/SO3_1.nc" }
+               ]
+            },
+            "quantum yield": {
+               "type": "base",
+               "constant value": 1.0
+            }
+         }
+      ]
+   },
+   "__CAM options": {
+     "aliasing": {
+       "default matching": "backup",
+       "pairs": [
+           {
+              "to": "jalknit",
+              "__reaction": "ALKNIT + hv -> NO2 + 0.4*CH3CHO + 0.1*CH2O + 0.25*CH3COCH3 + HO2 + 0.8*MEK",
+              "from": "jch3ooh"
+           },
+           {
+              "to": "jpooh",
+              "__reaction": "POOH (C3H6OHOOH) + hv -> CH3CHO + CH2O + HO2 + OH",
+              "from": "jch3ooh"
+           },
+           {
+              "to": "jch3co3h",
+              "__reaction": "CH3COOOH + hv -> CH3O2 + OH + CO2",
+              "from": "jh2o2",
+              "scale by": 0.28
+           },
+           {
+              "to": "jmpan",
+              "__reaction": "MPAN + hv -> MCO3 + NO2",
+              "from": "jpan"
+           },
+           {
+              "to": "jc2h5ooh",
+              "__reaction": "C2H5OOH + hv -> CH3CHO + HO2 + OH",
+              "from": "jch3ooh"
+           },
+           {
+              "to": "jc3h7ooh",
+              "__reaction": "C3H7OOH + hv -> 0.82*CH3COCH3 + OH + HO2",
+              "from": "jch3ooh"
+           },
+           {
+              "to": "jc6h5ooh",
+              "__reaction": "C6H5OOH + hv -> PHENO + OH",
+              "from": "jch3ooh"
+           },
+           {
+              "to": "jeooh",
+              "__reaction": "EOOH + hv -> EO + OH",
+              "from": "jch3ooh"
+           },
+           {
+              "to": "jrooh",
+              "__reaction": "ROOH + hv -> CH3CO3 + CH2O + OH",
+              "from": "jch3ooh"
+           },
+           {
+              "to": "jxooh",
+              "__reaction": "XOOH + hv -> OH",
+              "from": "jch3ooh"
+           },
+           {
+              "to": "jonitr",
+              "__reaction": "ONITR + hv -> NO2",
+              "from": "jch3cho"
+           },
+           {
+              "to": "jisopooh",
+              "__reaction": "ISOPOOH + hv -> 0.402*MVK + 0.288*MACR + 0.69*CH2O + HO2",
+              "from": "jch3ooh"
+           },
+           {
+              "to": "jmek",
+              "__reaction": "MEK + hv -> CH3CO3 + C2H5O2",
+              "from": "jacet"
+           },
+           {
+              "to": "jalkooh",
+              "__reaction": "ALKOOH + hv  -> .4*CH3CHO + .1*CH2O + .25*CH3COCH3 + .9*HO2 + .8*MEK + OH",
+              "from": "jch3ooh"
+           },
+           {
+              "to": "jbenzooh",
+              "__reaction": "BENZOOH + hv -> OH + GLYOXAL + 0.5*BIGALD1 + HO2",
+              "from": "jch3ooh"
+           },
+           {
+              "to": "jbepomuc",
+              "__reaction": "BEPOMUC + hv -> BIGALD1 + 1.5*HO2 + 1.5*CO",
+              "from": "jno2",
+              "scale by": 0.1
+           },
+           {
+              "to": "jbigald",
+              "__reaction": "BIGALD + hv -> 0.45*CO + 0.13*GLYOXAL + 0.56*HO2 + 0.13*CH3CO3 + 0.18*CH3COCHO",
+              "from": "jno2",
+              "scale by": 0.2
+           },
+           {
+              "to": "jbigald1",
+              "__reaction": "BIGALD1 + hv -> 0.6*MALO2 + HO2",
+              "from": "jno2",
+              "scale by": 0.14
+           },
+           {
+              "to": "jbigald2",
+              "__reaction": "BIGALD2 + hv -> 0.6*HO2 + 0.6*DICARBO2",
+              "from": "jno2",
+              "scale by": 0.2
+           },
+           {
+              "to": "jbigald3",
+              "__reaction": "BIGALD3 + hv -> 0.6*HO2 + 0.6*CO + 0.6*MDIALO2",
+              "from": "jno2",
+              "scale by": 0.2
+           },
+           {
+              "to": "jbigald4",
+              "__reaction": "BIGALD4 + hv -> HO2 + CO + CH3COCHO + CH3CO3",
+              "from": "jno2",
+              "scale by": 0.006
+           },
+           {
+              "to": "jbzooh",
+              "__reaction": "BZOOH + hv -> BZALD + OH + HO2",
+              "from": "jch3ooh"
+           },
+           {
+              "to": "jmekooh",
+              "__reaction": "MEKOOH + hv  -> OH + CH3CO3 + CH3CHO",
+              "from": "jch3ooh"
+           },
+           {
+              "to": "jtolooh",
+              "__reaction": "TOLOOH + hv  -> OH + .45*GLYOXAL + .45*CH3COCHO + .9*BIGALD",
+              "from": "jch3ooh"
+           },
+           {
+              "to": "jterpooh",
+              "__reaction": "TERPOOH + hv  -> OH + .1*CH3COCH3 + HO2 + MVK + MACR",
+              "from": "jch3ooh"
+           },
+           {
+              "to": "jhonitr",
+              "__reaction": "HONITR + hv -> NO2 + 0.67*HO2 + 0.33*CH3CHO + 0.33*CH2O + 0.33*CO + 0.33*GLYALD + 0.33*CH3CO3 + 0.17*HYAC + 0.17*CH3COCH3",
+              "from": "jch2o_a"
+           },
+           {
+              "to": "jhpald",
+              "__reaction": "HPALD + hv -> BIGALD3 + OH + HO2",
+              "from": "jno2",
+              "scale by": 0.006
+           },
+           {
+              "to": "jisopnooh",
+              "__reaction": "ISOPNOOH + hv -> NO2 + HO2 + ISOPOOH",
+              "from": "jch3ooh"
+           },
+           {
+              "to": "jnc4cho",
+              "__reaction": "NC4CHO + hv -> BIGALD3 + NO2 + HO2",
+              "from": "jch2o_a"
+           },
+           {
+              "to": "jnoa",
+              "__reaction": "NOA + hv -> NO2 + CH2O + CH3CO3",
+              "from": "jch2o_a"
+           },
+           {
+              "to": "jnterpooh",
+              "__reaction": "NTERPOOH + hv -> TERPROD1 + NO2 + OH",
+              "from": "jch3ooh"
+           },
+           {
+              "to": "jphenooh",
+              "__reaction": "PHENOOH + hv -> OH + HO2 + 0.7*GLYOXAL",
+              "from": "jch3ooh"
+           },
+           {
+              "to": "jtepomuc",
+              "__reaction": "TEPOMUC + hv -> 0.5*CH3CO3 + HO2 + 1.5*CO",
+              "from": "jno2",
+              "scale by": 0.1
+           },
+           {
+              "to": "jterp2ooh",
+              "__reaction": "TERP2OOH + hv -> OH + 0.375*CH2O + 0.3*CH3COCH3 + 0.25*CO + CO2 + TERPROD2 + HO2 + 0.25*GLYALD",
+              "from": "jch3ooh"
+           },
+           {
+              "to": "jterpnit",
+              "__reaction": "TERPNIT + hv -> TERPROD1 + NO2 + HO2",
+              "from": "jch3ooh"
+           },
+           {
+              "to": "jterprd1",
+              "__reaction": "TERPROD1 + hv -> HO2 + CO + TERPROD2",
+              "from": "jch3cho"
+           },
+           {
+              "to": "jterprd2",
+              "__reaction": "TERPROD2 + hv -> 0.15*RO2 + 0.68*CH2O + 0.8*CO2 + 0.5*CH3COCH3 + 0.65*CH3CO3 + 1.2*HO2 + 1.7*CO",
+              "from": "jch3cho"
+           },
+           {
+              "to": "jxylenooh",
+              "__reaction": "XYLENOOH + hv -> OH + HO2 + 0.34*GLYOXAL + 0.54*CH3COCHO + 0.06*BIGALD1 + 0.2*BIGALD2 + 0.15*BIGALD3 + 0.21*BIGALD4",
+              "from": "jch3ooh"
+           },
+           {
+              "to": "jxylolooh",
+              "__reaction": "XYLOLOOH + hv -> OH + 0.17*GLYOXAL + 0.51*CH3COCHO + HO2",
+              "from": "jch3ooh"
+           },
+           {
+              "to": "jsoa1_a1",
+              "__reaction": "soa1_a1 + hv -> Products",
+              "from": "jno2",
+              "scale by": 0.0004
+           },
+           {
+              "to": "jsoa1_a2",
+              "__reaction": "soa1_a2 + hv -> Products",
+              "from": "jno2",
+              "scale by": 0.0004
+           },
+           {
+              "to": "jsoa2_a1",
+              "__reaction": "soa2_a1 + hv -> Products",
+              "from": "jno2",
+              "scale by": 0.0004
+           },
+           {
+              "to": "jsoa2_a2",
+              "__reaction": "soa2_a2 + hv -> Products",
+              "from": "jno2",
+              "scale by": 0.0004
+           },
+           {
+              "to": "jsoa3_a1",
+              "__reaction": "soa3_a1 + hv -> Products",
+              "from": "jno2",
+              "scale by": 0.0004
+           },
+           {
+              "to": "jsoa3_a2",
+              "__reaction": "soa3_a2 + hv -> Products",
+              "from": "jno2",
+              "scale by": 0.0004
+           },
+           {
+              "to": "jsoa4_a1",
+              "__reaction": "soa4_a1 + hv -> Products",
+              "from": "jno2",
+              "scale by": 0.0004
+           },
+           {
+              "to": "jsoa4_a2",
+              "__reaction": "soa4_a2 + hv -> Products",
+              "from": "jno2",
+              "scale by": 0.0004
+           },
+           {
+              "to": "jsoa5_a1",
+              "__reaction": "soa5_a1 + hv -> Products",
+              "from": "jno2",
+              "scale by": 0.0004
+           },
+           {
+              "to": "jsoa5_a2",
+              "__reaction": "soa5_a2 + hv -> Products",
+              "from": "jno2",
+              "scale by": 0.0004
+           }
+        ]
+     }
+   }
+}

--- a/examples/tuv_5_4.json
+++ b/examples/tuv_5_4.json
@@ -1,4 +1,8 @@
 {
+   "__description": [
+     "TUV-x configuration that reporoduces photolysis rate constants of the TUV 5.4 calculator",
+     "The original TUV 5.4 source code and data sets can be found here: https://www2.acom.ucar.edu/modeling/tuv-download"
+   ],
    "O2 absorption" : {
      "cross section parameters file": "data/cross_sections/O2_parameters.txt"
    },
@@ -169,7 +173,6 @@
          }
       ]
    },
-    "__description": "This file contains configurations for each of the photolysis rate constants that can be calculated using data from this folder",
    "photolysis": {
       "enable diagnostics" : true,
       "reactions": [

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,7 +34,9 @@ endif()
 ################################################################################
 # Run examples as tests
 
-add_test(NAME full_example COMMAND tuv-x examples/full_config.json
+add_test(NAME TUV_5_4 COMMAND tuv-x examples/tuv_5_4.json
+         WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+add_test(NAME TS1_TSMLT COMMAND tuv-x examples/ts1_tsmlt.json
          WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
 ################################################################################


### PR DESCRIPTION
Adds a configuration for the TS1/TSMLT mechanism used in CAM-Chem/WACCM to the examples, and renames the existing example to indicate that it recreates the TUV 5.4 photolysis and dose rate calculations

closes #19