### PR TITLE
Address failure running tests on threads

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,13 +37,13 @@ endif()
 add_custom_target(make-tuv54-example-dir ALL COMMAND ${CMAKE_COMMAND}
                   -E make_directory ${CMAKE_BINARY_DIR}/example_tuv_5_4)
 add_custom_target(link-tuv54-example-data ALL COMMAND ${CMAKE_COMMAND}
-                  -E create_symlink ${CMAKE_BINARY_DIR}/data ${CMAKE_BINARY_DIR}/example_tuv_5_4/data)
+                  -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/../data ${CMAKE_BINARY_DIR}/example_tuv_5_4/data)
 add_test(NAME TUV_5_4 COMMAND tuv-x ../examples/tuv_5_4.json
          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/example_tuv_5_4)
 add_custom_target(make-ts1-tsmlt-example-dir ALL COMMAND ${CMAKE_COMMAND}
                   -E make_directory ${CMAKE_BINARY_DIR}/example_ts1_tsmlt)
 add_custom_target(link-ts1-tsmlt-example-data ALL COMMAND ${CMAKE_COMMAND}
-                  -E create_symlink ${CMAKE_BINARY_DIR}/data ${CMAKE_BINARY_DIR}/example_ts1_tsmlt/data)
+                  -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/../data ${CMAKE_BINARY_DIR}/example_ts1_tsmlt/data)
 add_test(NAME TS1_TSMLT COMMAND tuv-x ../examples/ts1_tsmlt.json
          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/example_ts1_tsmlt)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,9 +34,17 @@ endif()
 ################################################################################
 # Run examples as tests
 
-add_test(NAME TUV_5_4 COMMAND tuv-x examples/tuv_5_4.json
-         WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-add_test(NAME TS1_TSMLT COMMAND tuv-x examples/ts1_tsmlt.json
-         WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+add_custom_target(make-tuv54-example-dir ALL COMMAND ${CMAKE_COMMAND}
+                  -E make_directory ${CMAKE_BINARY_DIR}/example_tuv_5_4)
+add_custom_target(link-tuv54-example-data ALL COMMAND ${CMAKE_COMMAND}
+                  -E create_symlink ${CMAKE_BINARY_DIR}/data ${CMAKE_BINARY_DIR}/example_tuv_5_4/data)
+add_test(NAME TUV_5_4 COMMAND tuv-x ../examples/tuv_5_4.json
+         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/example_tuv_5_4)
+add_custom_target(make-ts1-tsmlt-example-dir ALL COMMAND ${CMAKE_COMMAND}
+                  -E make_directory ${CMAKE_BINARY_DIR}/example_ts1_tsmlt)
+add_custom_target(link-ts1-tsmlt-example-data ALL COMMAND ${CMAKE_COMMAND}
+                  -E create_symlink ${CMAKE_BINARY_DIR}/data ${CMAKE_BINARY_DIR}/example_ts1_tsmlt/data)
+add_test(NAME TS1_TSMLT COMMAND tuv-x ../examples/ts1_tsmlt.json
+         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/example_ts1_tsmlt)
 
 ################################################################################


### PR DESCRIPTION
Creates sub-folders in the build directory to run tests of example configurations, so they don't try to create/edit the same output file when running concurrently