### PR TITLE
Add ability to calculate heating rates for photolysis reactions

### DIFF
--- a/examples/ts1_tsmlt.json
+++ b/examples/ts1_tsmlt.json
@@ -199,6 +199,9 @@
                   "value": 1.0
                 }
               ]
+            },
+            "heating" : {
+               "energy term": 175.05
             }
          },
          {
@@ -228,6 +231,9 @@
                    "value": 0.0
                  }
                ]
+            },
+            "heating" : {
+               "energy term": 242.37
             }
          },
          {
@@ -244,6 +250,9 @@
             },
             "quantum yield": {
                "type": "O3+hv->O2+O(1D)"
+            },
+            "heating" : {
+               "energy term": 310.32
             }
          },
          {
@@ -260,6 +269,9 @@
             },
             "quantum yield": {
                "type": "O3+hv->O2+O(3P)"
+            },
+            "heating" : {
+               "energy term": 1179.87
             }
          },
          {

--- a/examples/ts1_tsmlt.yml
+++ b/examples/ts1_tsmlt.yml
@@ -210,6 +210,8 @@ photolysis:
         lower extrapolation:
           type: boundary
       type: base
+    heating:
+      energy term: 175.05
     name: jo2_a
     quantum yield:
       constant value: 0
@@ -229,6 +231,8 @@ photolysis:
         lower extrapolation:
           type: boundary
       type: base
+    heating:
+      energy term: 242.37
     name: jo2_b
     quantum yield:
       constant value: 1.0
@@ -246,6 +250,8 @@ photolysis:
       - file path: data/cross_sections/O3_3.nc
       - file path: data/cross_sections/O3_4.nc
       type: O3
+    heating:
+      energy term: 310.32
     name: jo3_a
     quantum yield:
       type: O3+hv->O2+O(1D)
@@ -257,6 +263,8 @@ photolysis:
       - file path: data/cross_sections/O3_3.nc
       - file path: data/cross_sections/O3_4.nc
       type: O3
+    heating:
+      energy term: 1179.87
     name: jo3_b
     quantum yield:
       type: O3+hv->O2+O(3P)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,6 +46,7 @@ target_sources(tuvx_object
     grid.F90
     grid_factory.F90
     grid_warehouse.F90
+    heating_rates.F90
     interpolate.F90
     la_sr_bands.F90
     linear_algebra.F90

--- a/src/grid_warehouse.F90
+++ b/src/grid_warehouse.F90
@@ -152,10 +152,10 @@ contains
     use musica_string,                 only : string_t
     use tuvx_grid,                     only : grid_t
 
-    class(grid_warehouse_t), intent(inout) :: this ! This :f:type:`~tuvx_grid_warehouse/grid_warehouse_t`
-    type(string_t),          intent(in)    :: name ! The name of a grid, see :ref:`configuration-grids` for grid names
-    type(string_t),          intent(in)    :: units ! The units of the grid
-    class(grid_t), pointer                 :: a_grid_ptr ! The :f:type:`~tuvx_grid/grid_t` which matches the name passed in
+    class(grid_warehouse_t), intent(in) :: this ! This :f:type:`~tuvx_grid_warehouse/grid_warehouse_t`
+    type(string_t),          intent(in) :: name ! The name of a grid, see :ref:`configuration-grids` for grid names
+    type(string_t),          intent(in) :: units ! The units of the grid
+    class(grid_t), pointer              :: a_grid_ptr ! The :f:type:`~tuvx_grid/grid_t` which matches the name passed in
 
     a_grid_ptr => this%get_grid_char( name%to_char( ), units%to_char( ) )
 
@@ -169,9 +169,9 @@ contains
     use musica_assert,                 only : assert_msg
     use tuvx_grid,                     only : grid_t
 
-    class(grid_warehouse_t),  intent(inout) :: this ! This grid warehouse
-    type(grid_warehouse_ptr), intent(in)    :: ptr  ! Pointer to a grid in the warehouse
-    class(grid_t),            pointer       :: grid
+    class(grid_warehouse_t),  intent(in) :: this ! This grid warehouse
+    type(grid_warehouse_ptr), intent(in) :: ptr  ! Pointer to a grid in the warehouse
+    class(grid_t),            pointer    :: grid
 
     call assert_msg( 870082797, ptr%index_ > 0, "Invalid grid pointer" )
     allocate( grid, source = this%grids_( ptr%index_ )%val_ )

--- a/src/heating_rates.F90
+++ b/src/heating_rates.F90
@@ -52,6 +52,8 @@ module tuvx_heating_rates
     procedure :: get
     !> Returns the names of each photolysis reaction with a heating rate
     procedure :: labels
+    !> Returns the number of heating rates
+    procedure :: size => get_number
     !> Returns the size of a character buffer needed to pack the heating rates
     procedure :: pack_size
     !> Packs the heating rates into a character buffer
@@ -250,7 +252,7 @@ contains
     class(profile_warehouse_t),  intent(inout) :: profiles
     !> Radiation field
     class(radiation_field_t),    intent(in)    :: radiation_field
-    !> Heating rates (vertical interface, reaction)
+    !> Heating rates (vertical interface, reaction) [J s-1]
     real(kind=dk),               intent(inout) :: heating_rates(:,:)
 
     character(len=*), parameter :: Iam = 'heating rates get'
@@ -329,6 +331,23 @@ contains
     labels(:) = this%heating_parameters_(:)%label_
 
   end function labels
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  !> Returns the number of heating rates
+  function get_number( this ) result( n_rates )
+
+    !> Number of heating rates
+    integer :: n_rates
+    !> Heating rate collection
+    class(heating_rates_t), intent(in) :: this
+
+    n_rates = 0
+    if( allocated( this%heating_parameters_ ) ) then
+      n_rates = size( this%heating_parameters_ )
+    end if
+
+  end function get_number
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/src/heating_rates.F90
+++ b/src/heating_rates.F90
@@ -1,0 +1,588 @@
+! Copyright (C) 2024 National Center for Atmospheric Research
+! SPDX-License-Identifier: Apache-2.0
+!
+module tuvx_heating_rates
+  ! The chemical potential heating rates type heating_rates_t and related functions
+
+  use musica_constants,                only : dk => musica_dk
+  use musica_string,                   only : string_t
+  use tuvx_cross_section,              only : cross_section_ptr
+  use tuvx_grid_warehouse,             only : grid_warehouse_ptr
+  use tuvx_profile_warehouse,          only : profile_warehouse_ptr
+  use tuvx_quantum_yield,              only : quantum_yield_ptr
+
+  implicit none
+
+  private
+  public :: heating_rates_t
+
+  type :: heating_parameters_t
+    ! Heating parameters for a single photolyzing species
+    type(string_t)             :: label_         ! label for the heating rate
+    type(cross_section_ptr)    :: cross_section_ ! cross section
+    type(quantum_yield_ptr)    :: quantum_yield_ ! quantum yield
+    real(kind=dk), allocatable :: energy_(:)     ! wavelength resolved bond-dissociation energy [J]
+  contains
+    !> Returns the size of a character buffer needed to pack the heating parameters
+    procedure :: pack_size => heating_parameters_pack_size
+    !> Packs the heating parameters into a character buffer
+    procedure :: mpi_pack => heating_parameters_mpi_pack
+    !> Unpacks the heating parameters from a character buffer
+    procedure :: mpi_unpack => heating_parameters_mpi_unpack
+  end type heating_parameters_t
+
+  !> heating_parameters_t constructor
+  interface heating_parameters_t
+    module procedure :: heating_parameters_constructor
+  end interface heating_parameters_t
+
+  type, public :: heating_rates_t
+    type(heating_parameters_t), allocatable :: heating_parameters_(:) ! heating parameters for each photolyzing species
+    type(grid_warehouse_ptr) :: height_grid_     ! height grid
+    type(grid_warehouse_ptr) :: wavelength_grid_ ! wavelength grid
+    type(profile_warehouse_ptr) :: etfl_profile_ ! Extraterrestrial flux profile
+    type(profile_warehouse_ptr) :: air_profile_  ! Air profile
+    integer, allocatable :: o2_rate_indices_(:)  ! indices in the heating rates array where O2
+                                                 ! corrections to the cross-section in the
+                                                 ! Lyman-Alpha and Schumann-Runge bands should
+                                                 ! be applied
+  contains
+    !> Calulates the heating rates
+    procedure :: get
+    !> Returns the names of each photolysis reaction with a heating rate
+    procedure :: labels
+    !> Returns the size of a character buffer needed to pack the heating rates
+    procedure :: pack_size
+    !> Packs the heating rates into a character buffer
+    procedure :: mpi_pack
+    !> Unpacks the heating rates from a character buffer
+    procedure :: mpi_unpack
+    !> Cleans up memory
+    final :: destructor
+  end type heating_rates_t
+
+  !> heating_rates_t constructor
+  interface heating_rates_t
+    module procedure :: constructor
+  end interface heating_rates_t
+
+contains
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  !> heating_rates_t constructor
+  function constructor( config, grids, profiles ) result( this )
+
+    use musica_assert,                 only : assert, assert_msg
+    use musica_config,                 only : config_t
+    use musica_iterator,               only : iterator_t
+    use tuvx_grid_warehouse,           only : grid_warehouse_t
+    use tuvx_profile_warehouse,        only : profile_warehouse_t
+
+    !> Heating rate collection
+    type(heating_rates_t),     pointer       :: this
+    !> Configuration
+    type(config_t),            intent(inout) :: config
+    !> Grids
+    type(grid_warehouse_t),    intent(inout) :: grids
+    !> Profiles
+    type(profile_warehouse_t), intent(inout) :: profiles
+
+    character(len=*), parameter :: Iam = 'heating rates constructor'
+    type(config_t) :: reaction_set, reaction_config, heating_config
+    class(iterator_t), pointer :: iter
+    type(string_t) :: label
+    type(string_t) :: required_keys(1), optional_keys(1)
+    logical :: found, do_apply_bands
+    integer :: n_hr, i_hr, n_O2, i_O2
+
+    required_keys(1) = "reactions"
+    optional_keys(1) = "enable diagnostics"
+
+    call assert_msg( 310567326,                                               &
+                     config%validate( required_keys, optional_keys ),         &
+                      "Invalid configuration for heating rates" )
+
+    allocate( this )
+    this%height_grid_ = grids%get_ptr( "height", "km" )
+    this%wavelength_grid_ = grids%get_ptr( "wavelength", "nm" )
+    this%etfl_profile_ = profiles%get_ptr( "extraterrestrial flux",           &
+                                           "photon cm-2 s-1" )
+    this%air_profile_ = profiles%get_ptr( "air", "molecule cm-3" )
+
+    ! iterate over photolysis reactions looking for those with
+    ! heating rate parameters
+    allocate( this%o2_rate_indices_( 0 ) )
+    call config%get( "reactions", reaction_set, Iam )
+    iter => reaction_set%get_iterator( )
+    n_hr = 0
+    n_O2 = 0
+    do while( iter%next( ) )
+      call reaction_set%get( iter, reaction_config, Iam )
+      call reaction_config%get( "heating", heating_config, Iam, found = found )
+      if( found ) then
+        n_hr = n_hr + 1
+        call reaction_config%get( "apply O2 bands", do_apply_bands, Iam,      &
+                                  default = .false. )
+        if( do_apply_bands ) n_O2 = n_O2 + 1
+      end if
+    end do
+    allocate( this%heating_parameters_( n_hr ) )
+    call iter%reset( )
+    i_hr = 0
+    i_O2 = 0
+    do while( iter%next( ) )
+      call reaction_set%get( iter, reaction_config, Iam )
+      call reaction_config%get( "heating", heating_config, Iam, found = found )
+      if( found ) then
+        i_hr = i_hr + 1
+        call reaction_config%get( "name", label, Iam )
+        this%heating_parameters_( i_hr ) =                                    &
+          heating_parameters_constructor( reaction_config, grids, profiles )
+        call reaction_config%get( "apply O2 bands", do_apply_bands, Iam,      &
+                                  default = .false. )
+        if( do_apply_bands ) then
+          i_O2 = i_O2 + 1
+          this%o2_rate_indices_( i_O2 ) = i_hr
+        end if
+      end if
+    end do
+    call assert( 357615745, i_hr .eq. n_hr )
+    call assert( 336635308, i_O2 .eq. n_O2 )
+    deallocate( iter )
+
+  end function constructor
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  !> heating_parameters_t constructor
+  function heating_parameters_constructor( config, grids, profiles )          &
+      result( this )
+
+    use musica_assert,                 only : assert_msg
+    use musica_config,                 only : config_t
+    use tuvx_constants,                only : hc
+    use tuvx_cross_section_factory,    only : cross_section_builder
+    use tuvx_grid,                     only : grid_t
+    use tuvx_grid_warehouse,           only : grid_warehouse_t
+    use tuvx_profile_warehouse,        only : profile_warehouse_t
+    use tuvx_quantum_yield_factory,    only : quantum_yield_builder
+
+    !> Heating parameters for a single photolyzing species
+    type(heating_parameters_t)               :: this
+    !> Configuration for the photolysis reaction
+    type(config_t),            intent(inout) :: config
+    !> Grids
+    type(grid_warehouse_t),    intent(inout) :: grids
+    !> Profiles
+    type(profile_warehouse_t), intent(inout) :: profiles
+
+    character(len=*), parameter :: Iam = 'heating parameters constructor'
+    type(config_t) :: heating_config, cs_config, qy_config
+    class(grid_t), pointer :: wavelengths
+    real(kind=dk) :: energy_term
+    type(string_t) :: required_keys(4), optional_keys(1)
+    type(string_t) :: heating_required_keys(1), heating_optional_keys(0)
+
+    required_keys(1) = "name"
+    required_keys(2) = "cross section"
+    required_keys(3) = "quantum yield"
+    required_keys(4) = "heating"
+    optional_keys(1) = "scaling factor"
+
+    call assert_msg( 316144353,                                               &
+                     config%validate( required_keys, optional_keys ),         &
+                     "Invalid configuration for photolysis reactions with "// &
+                     "heating parameters" )
+
+    call config%get( "heating", heating_config, Iam )
+
+    heating_required_keys(1) = "energy term"
+
+    call assert_msg( 316144354,                                               &
+                     heating_config%validate( heating_required_keys,          &
+                                              heating_optional_keys ), &
+                     "Invalid configuration for heating parameters" )
+
+    call config%get( "name", this%label_, Iam )
+    call config%get( "cross section", cs_config, Iam )
+    this%cross_section_%val_ => cross_section_builder( cs_config, grids,      &
+                                                       profiles )
+    call config%get( "quantum yield", qy_config, Iam )
+    this%quantum_yield_%val_ => quantum_yield_builder( qy_config, grids,      &
+                                                       profiles )
+    call heating_config%get( "energy term", energy_term, Iam )
+    wavelengths => grids%get_grid( "wavelength", "nm" )
+    allocate( this%energy_( wavelengths%ncells_ ) )
+    this%energy_(:) =                                                         &
+        max( 0.0_dk, hc * 1.0e9_dk * ( energy_term - wavelengths%mid_(:) ) /  &
+                                     ( energy_term * wavelengths%mid_(:) ) )
+    deallocate( wavelengths )
+
+  end function heating_parameters_constructor
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  !> calculate heating rates
+  subroutine get( this, la_srb, spherical_geometry, grids, profiles,          &
+                  radiation_field, heating_rates )
+
+    use musica_assert,                 only : assert
+    use tuvx_grid,                     only : grid_t
+    use tuvx_grid_warehouse,           only : grid_warehouse_t
+    use tuvx_la_sr_bands,              only : la_sr_bands_t
+    use tuvx_profile,                  only : profile_t
+    use tuvx_profile_warehouse,        only : profile_warehouse_t
+    use tuvx_solver,                   only : radiation_field_t
+    use tuvx_spherical_geometry,       only : spherical_geometry_t
+
+    !> Heating rate collection
+    class(heating_rates_t),      intent(in)    :: this
+    !> Lyman Alpha and Schumann-Runge bands
+    class(la_sr_bands_t),        intent(inout) :: la_srb
+    !> Spherical geometry
+    class(spherical_geometry_t), intent(inout) :: spherical_geometry
+    !> Grids
+    class(grid_warehouse_t),     intent(inout) :: grids
+    !> Profiles
+    class(profile_warehouse_t),  intent(inout) :: profiles
+    !> Radiation field
+    class(radiation_field_t),    intent(in)    :: radiation_field
+    !> Heating rates
+    real(kind=dk),               intent(inout) :: heating_rates(:,:)
+
+    character(len=*), parameter :: Iam = 'heating rates get'
+    class(grid_t), pointer :: heights, wavelengths
+    class(profile_t), pointer :: etfl, air
+    real(kind=dk), allocatable :: actinic_flux(:,:), xsqy(:,:)
+    real(kind=dk), allocatable :: cross_section(:,:), quantum_yield(:,:)
+    real(kind=dk), allocatable :: air_vertical_column(:), air_slant_column(:)
+    integer :: i_rate, n_rates, i_height
+
+    heights => grids%get_grid( this%height_grid_ )
+    wavelengths => grids%get_grid( this%wavelength_grid_ )
+    etfl => profiles%get_profile( this%etfl_profile_ )
+    air => profiles%get_profile( this%air_profile_ )
+
+    n_rates = size( this%heating_parameters_ )
+    call assert( 966855732,                                                   &
+                 size( heating_rates, 1 ) .eq. heights%ncells_ + 1 .and.      &
+                 size( heating_rates, 2 ) .eq. n_rates )
+
+    actinic_flux = transpose( radiation_field%fdr_ + radiation_field%fup_ +   &
+                              radiation_field%fdn_ )
+    do i_height = 1, heights%ncells_ + 1
+      actinic_flux( :, i_height ) = actinic_flux( :, i_height ) * etfl%mid_val_
+    end do
+    where( actinic_flux < 0.0_dk )
+      actinic_flux = 0.0_dk
+    end where
+
+    do i_rate = 1, n_rates
+    associate( params => this%heating_parameters_( i_rate ) )
+      cross_section = params%cross_section_%val_%calculate( grids, profiles )
+      quantum_yield = params%quantum_yield_%val_%calculate( grids, profiles )
+
+      ! O2 photolysis can have special la & srb band handling
+      if( any( this%o2_rate_indices_ == i_rate ) ) then
+        allocate( air_vertical_column( air%ncells_ ),                         &
+                  air_slant_column( air%ncells_ + 1 ) )
+        call spherical_geometry%air_mass( air%exo_layer_dens_,                &
+                                          air_vertical_column,                &
+                                          air_slant_column )
+        call la_srb%cross_section( grids, profiles, air_vertical_column,      &
+                                   air_slant_column, cross_section,           &
+                                   spherical_geometry )
+        deallocate( air_vertical_column, air_slant_column )
+      end if
+
+      xsqy = transpose( cross_section * quantum_yield )
+      do i_height = 1, heights%ncells_ + 1
+        heating_rates( i_height, i_rate ) =                                   &
+            dot_product( actinic_flux( :, i_height ),                         &
+                         params%energy_(:) * xsqy( :, i_height ) )
+      end do
+    end associate
+    end do
+
+    deallocate( heights )
+    deallocate( wavelengths )
+    deallocate( etfl )
+    deallocate( air )
+
+  end subroutine get
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  !> Returns the names of each photolysis reaction with a heating rate
+  function labels( this )
+
+    !> Photolysis reaction labels
+    type(string_t), allocatable :: labels(:)
+    !> Heating rate collection
+    class(heating_rates_t), intent(in) :: this
+
+    allocate( labels( size( this%heating_parameters_ ) ) )
+    labels(:) = this%heating_parameters_(:)%label_
+
+  end function labels
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  !> Returns the size of a character buffer needed to pack the heating rates
+  function pack_size( this, comm )
+
+    use musica_mpi,                    only : musica_mpi_pack_size
+
+    !> Heating rate collection
+    class(heating_rates_t), intent(in) :: this
+    !> MPI communicator
+    integer,                intent(in) :: comm
+    !> Size of the character buffer
+    integer                            :: pack_size
+
+#ifdef MUSICA_USE_MPI
+    integer :: i_elem
+
+    pack_size = musica_mpi_pack_size( allocated( this%heating_parameters_ ),  &
+                                      comm )
+    if( allocated( this%heating_parameters_ ) ) then
+      pack_size = pack_size +                                                 &
+          musica_mpi_pack_size( size( this%heating_parameters_ ), comm )
+      do i_elem = 1, size( this%heating_parameters_ )
+        pack_size = pack_size +                                               &
+            this%heating_parameters_( i_elem )%pack_size( comm )
+      end do
+    end if
+    pack_size = pack_size +                                                   &
+                this%height_grid_%pack_size( comm ) +                         &
+                this%wavelength_grid_%pack_size( comm ) +                     &
+                this%etfl_profile_%pack_size( comm ) +                        &
+                this%air_profile_%pack_size( comm ) +                         &
+                musica_mpi_pack_size( this%o2_rate_indices_, comm )
+#else
+    pack_size = 0
+#endif
+
+  end function pack_size
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  !> Packs the heating rates into a character buffer
+  subroutine mpi_pack( this, buffer, position, comm )
+
+    use musica_assert,                 only : assert
+    use musica_mpi,                    only : musica_mpi_pack
+
+    !> Heating rate collection
+    class(heating_rates_t), intent(in)    :: this
+    !> Character buffer
+    character,              intent(inout) :: buffer(:)
+    !> Position in the buffer
+    integer,                intent(inout) :: position
+    !> MPI communicator
+    integer,                intent(in) :: comm
+
+#ifdef MUSICA_USE_MPI
+    integer :: prev_pos, i_elem
+
+    prev_pos = position
+    call musica_mpi_pack( buffer, position,                                   &
+                          allocated( this%heating_parameters_ ), comm )
+    if( allocated( this%heating_parameters_ ) ) then
+      call musica_mpi_pack( buffer, position,                                 &
+                            size( this%heating_parameters_ ), comm )
+      do i_elem = 1, size( this%heating_parameters_ )
+        call this%heating_parameters_( i_elem )%mpi_pack( buffer, position,   &
+                                                          comm )
+      end do
+    end if
+    call this%height_grid_%mpi_pack( buffer, position, comm )
+    call this%wavelength_grid_%mpi_pack( buffer, position, comm )
+    call this%etfl_profile_%mpi_pack( buffer, position, comm )
+    call this%air_profile_%mpi_pack( buffer, position, comm )
+    call musica_mpi_pack( buffer, position, this%o2_rate_indices_, comm )
+    call assert( 247051769, position - prev_pos <= this%pack_size( comm ) )
+#endif
+
+  end subroutine mpi_pack
+  
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  !> Unpacks the heating rates from a character buffer
+  subroutine mpi_unpack( this, buffer, position, comm )
+
+    use musica_assert,                 only : assert
+    use musica_mpi,                    only : musica_mpi_unpack
+
+    !> Heating rate collection
+    class(heating_rates_t), intent(out) :: this
+    !> Character buffer
+    character,              intent(inout) :: buffer(:)
+    !> Position in the buffer
+    integer,                intent(inout) :: position
+    !> MPI communicator
+    integer,                intent(in)    :: comm
+
+#ifdef MUSICA_USE_MPI
+    integer :: prev_pos, i_elem, n_elems
+    logical :: is_allocated
+
+    prev_pos = position
+    call musica_mpi_unpack( buffer, position, is_allocated, comm )
+    if( is_allocated ) then
+      call musica_mpi_unpack( buffer, position, n_elems, comm )
+      allocate( this%heating_parameters_( n_elems ) )
+      do i_elem = 1, n_elems
+        call this%heating_parameters_( i_elem )%mpi_unpack( buffer, position, &
+                                                            comm )
+      end do
+    end if
+    call this%height_grid_%mpi_unpack( buffer, position, comm )
+    call this%wavelength_grid_%mpi_unpack( buffer, position, comm )
+    call this%etfl_profile_%mpi_unpack( buffer, position, comm )
+    call this%air_profile_%mpi_unpack( buffer, position, comm )
+    call musica_mpi_unpack( buffer, position, this%o2_rate_indices_, comm )
+    call assert( 631316749, position - prev_pos <= this%pack_size( comm ) )
+#endif
+
+  end subroutine mpi_unpack
+  
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  !> Returns the size of a character buffer needed to pack the heating
+  !! parameters
+  function heating_parameters_pack_size( this, comm ) result( pack_size )
+
+    use musica_mpi,                    only : musica_mpi_pack_size
+    use tuvx_cross_section_factory,    only : cross_section_type_name
+    use tuvx_quantum_yield_factory,    only : quantum_yield_type_name
+
+    !> Heating parameters for a single photolyzing species
+    class(heating_parameters_t), intent(in) :: this
+    !> MPI communicator
+    integer,                     intent(in) :: comm
+    !> Size of the character buffer
+    integer                                 :: pack_size
+
+#ifdef MUSICA_USE_MPI
+    type(string_t) :: cs_type_name, qy_type_name
+
+    cs_type_name = cross_section_type_name( this%cross_section_%val_ )
+    qy_type_name = quantum_yield_type_name( this%quantum_yield_%val_ )
+    pack_size = this%label_%pack_size(  comm ) +                              &
+                cs_type_name%pack_size( comm ) +                              &
+                this%cross_section_%val_%pack_size( comm ) +                  &
+                qy_type_name%pack_size( comm ) +                              &
+                this%quantum_yield_%val_%pack_size( comm ) +                  &
+                musica_mpi_pack_size( this%energy_, comm )
+#else
+    pack_size = 0
+#endif
+
+  end function heating_parameters_pack_size
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  !> Packs the heating parameters into a character buffer
+  subroutine heating_parameters_mpi_pack( this, buffer, position, comm )
+
+    use musica_assert,                 only : assert
+    use musica_mpi,                    only : musica_mpi_pack
+    use tuvx_cross_section_factory,    only : cross_section_type_name
+    use tuvx_quantum_yield_factory,    only : quantum_yield_type_name
+
+    !> Heating parameters for a single photolyzing species
+    class(heating_parameters_t), intent(in)    :: this
+    !> Character buffer
+    character,                   intent(inout) :: buffer(:)
+    !> Position in the buffer
+    integer,                     intent(inout) :: position
+    !> MPI communicator
+    integer,                     intent(in)    :: comm
+
+#ifdef MUSICA_USE_MPI
+    integer :: prev_pos
+    type(string_t) :: cs_type_name, qy_type_name
+
+    prev_pos = position
+    cs_type_name = cross_section_type_name( this%cross_section_%val_ )
+    qy_type_name = quantum_yield_type_name( this%quantum_yield_%val_ )
+    call this%label_%mpi_pack( buffer, position, comm )
+    call cs_type_name%mpi_pack( buffer, position, comm )
+    call this%cross_section_%val_%mpi_pack( buffer, position, comm )
+    call qy_type_name%mpi_pack( buffer, position, comm )
+    call this%quantum_yield_%val_%mpi_pack( buffer, position, comm )
+    call musica_mpi_pack( buffer, position, this%energy_, comm )
+    call assert( 243240701, position - prev_pos <= this%pack_size( comm ) )
+#endif
+
+  end subroutine heating_parameters_mpi_pack
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  !> Unpacks the heating parameters from a character buffer
+  subroutine heating_parameters_mpi_unpack( this, buffer, position, comm )
+
+    use musica_assert,                 only : assert
+    use musica_mpi,                    only : musica_mpi_unpack
+    use tuvx_cross_section_factory,    only : cross_section_allocate
+    use tuvx_quantum_yield_factory,    only : quantum_yield_allocate
+
+    !> Heating parameters for a single photolyzing species
+    class(heating_parameters_t), intent(out) :: this
+    !> Character buffer
+    character,                   intent(inout) :: buffer(:)
+    !> Position in the buffer
+    integer,                     intent(inout) :: position
+    !> MPI communicator
+    integer,                     intent(in)    :: comm
+
+#ifdef MUSICA_USE_MPI
+    integer :: prev_pos
+    type(string_t) :: cs_type_name, qy_type_name
+
+    prev_pos = position
+    call this%label_%mpi_unpack( buffer, position, comm )
+    call cs_type_name%mpi_unpack( buffer, position, comm )
+    this%cross_section_%val_ => cross_section_allocate( cs_type_name )
+    call this%cross_section_%val_%mpi_unpack( buffer, position, comm )
+    call qy_type_name%mpi_unpack( buffer, position, comm )
+    this%quantum_yield_%val_ => quantum_yield_allocate( qy_type_name )
+    call this%quantum_yield_%val_%mpi_unpack( buffer, position, comm )
+    call musica_mpi_unpack( buffer, position, this%energy_, comm )
+    call assert( 243240702, position - prev_pos <= this%pack_size( comm ) )
+#endif
+
+  end subroutine heating_parameters_mpi_unpack
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  !> Cleans up memory
+  elemental subroutine destructor( this )
+
+    !> Heating rates
+    type(heating_rates_t), intent(inout) :: this
+
+    integer :: i_rate
+
+    if( allocated( this%heating_parameters_ ) ) then
+      do i_rate = 1, size( this%heating_parameters_ )
+      associate( params => this%heating_parameters_( i_rate ) )
+        if( associated( params%cross_section_%val_ ) ) then
+          deallocate( params%cross_section_%val_ )
+          nullify( params%cross_section_%val_ )
+        end if
+        if( associated( params%quantum_yield_%val_ ) ) then
+          deallocate( params%quantum_yield_%val_ )
+          nullify( params%quantum_yield_%val_ )
+        end if
+      end associate
+      end do
+      deallocate( this%heating_parameters_ )
+    end if
+
+  end subroutine destructor
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+end module tuvx_heating_rates

--- a/src/photolysis_rates.F90
+++ b/src/photolysis_rates.F90
@@ -178,7 +178,7 @@ contains
     real(dk)                :: scale_factor
     type(string_t)          :: reaction_key
     logical                 :: do_apply_bands, found
-    type(string_t)          :: required_keys(3), optional_keys(1)
+    type(string_t)          :: required_keys(3), optional_keys(2)
     type(cross_section_ptr), allocatable :: temp_cs(:)
     type(quantum_yield_ptr), allocatable :: temp_qy(:)
     type(string_t),          allocatable :: temp_handle(:)
@@ -190,6 +190,7 @@ contains
     required_keys(2) = "cross section"
     required_keys(3) = "quantum yield"
     optional_keys(1) = "scaling factor"
+    optional_keys(2) = "heating"
 
     call assert_msg( 780273355,                                               &
                      config%validate( required_keys, optional_keys ),         &

--- a/src/photolysis_rates.F90
+++ b/src/photolysis_rates.F90
@@ -373,7 +373,8 @@ rate_loop:                                                                    &
       xsqy = transpose( cross_section * quantum_yield )
       do vertNdx = 1, zGrid%ncells_ + 1
         photolysis_rates( vertNdx, rateNdx ) =                                &
-            dot_product( actinicFlux( :, vertNdx ), xsqy( :, vertNdx ) )
+            dot_product( actinicFlux( :, vertNdx ), xsqy( :, vertNdx ) ) *    &
+            this%scaling_factors_( rateNdx )
       enddo
       if( allocated( cross_section ) ) deallocate( cross_section )
       if( allocated( quantum_yield ) ) deallocate( quantum_yield )

--- a/test/data/heating_rates.json
+++ b/test/data/heating_rates.json
@@ -1,0 +1,100 @@
+{
+  "grids" : [
+    {
+      "name": "height",
+      "type": "equal interval",
+      "units": "km",
+      "begins at": 1.0,
+      "ends at": 5.0,
+      "cell delta": 1.0
+    },
+    {
+      "name": "wavelength",
+      "type": "equal interval",
+      "units": "nm",
+      "begins at": 400.0,
+      "ends at": 700.0,
+      "cell delta": 50.0
+    }
+  ],
+  "profiles": [
+    {
+      "name": "temperature",
+      "type": "from config file",
+      "units": "K",
+      "grid": {
+        "name": "height",
+        "units": "km"
+      },
+      "values": [ 200.0, 250.0, 300.0, 350.0, 400.0 ]
+    },
+    {
+      "name": "extraterrestrial flux",
+      "type": "from config file",
+      "units": "photon cm-2 s-1",
+      "grid": {
+        "name": "wavelength",
+        "units": "nm"
+      },
+      "values": [ 1.0e+14, 1.0e+15, 1.0e+16, 1.0e+17, 1.0e+18, 1.0e+19, 1.0e+20 ]
+    },
+    {
+      "name": "air",
+      "type": "from config file",
+      "units": "molecule cm-3",
+      "grid": {
+        "name": "height",
+        "units": "km"
+      },
+      "values": [ 2.5e+19, 2.0e+19, 1.5e+19, 1.0e+19, 5.0e+18 ]
+    }
+  ],
+  "reactions": [
+    {
+      "name": "jfoo",
+      "cross section": {
+        "type": "base",
+        "data": {
+          "default value": 12.3
+        }
+      },
+      "quantum yield": {
+        "type": "base",
+        "constant value": 0.75
+      },
+      "scaling factor": 1.1,
+      "heating": {
+        "energy term": 2.0
+      }
+    },
+    {
+      "name": "jbar",
+      "cross section": {
+        "type": "base",
+        "data": {
+          "default value": 45.6
+        }
+      },
+      "quantum yield": {
+        "type": "base",
+        "constant value": 0.25
+      }
+    },
+    {
+      "name": "jbaz",
+      "cross section": {
+        "type": "base",
+        "data": {
+          "default value": 78.9
+        }
+      },
+      "quantum yield": {
+        "type": "base",
+        "constant value": 0.5
+      },
+      "heating": {
+        "energy term": 3.0
+      }
+    }
+  ]
+}

--- a/test/data/heating_rates.json
+++ b/test/data/heating_rates.json
@@ -36,7 +36,7 @@
         "name": "wavelength",
         "units": "nm"
       },
-      "values": [ 1.0e+14, 1.0e+15, 1.0e+16, 1.0e+17, 1.0e+18, 1.0e+19, 1.0e+20 ]
+      "values": [ 1.0e+4, 1.0e+5, 1.0e+6, 1.0e+7, 1.0e+8, 1.0e+9, 1.0e+10 ]
     },
     {
       "name": "air",
@@ -62,7 +62,6 @@
         "type": "base",
         "constant value": 0.75
       },
-      "scaling factor": 1.1,
       "heating": {
         "energy term": 2.0
       }
@@ -92,8 +91,9 @@
         "type": "base",
         "constant value": 0.5
       },
+      "scaling factor": 1.1,
       "heating": {
-        "energy term": 3.0
+        "energy term": 3000.0
       }
     }
   ]

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -19,6 +19,7 @@ add_subdirectory(tuv_doug)
 # TUV-x tests
 
 create_standard_test(NAME grid_warehouse SOURCES grid_warehouse.F90)
+create_standard_test(NAME heating_rates SOURCES heating_rates.F90)
 create_standard_test(NAME la_sr_bands SOURCES la_sr_bands.F90 )
 create_standard_test(NAME spherical_geometry SOURCES spherical_geometry.F90 )
 

--- a/test/unit/heating_rates.F90
+++ b/test/unit/heating_rates.F90
@@ -28,7 +28,10 @@ contains
                                               MPI_COMM_WORLD
     use musica_string,                 only : string_t
     use tuvx_grid_warehouse,           only : grid_warehouse_t
+    use tuvx_la_sr_bands,              only : la_sr_bands_t
     use tuvx_profile_warehouse,        only : profile_warehouse_t
+    use tuvx_solver,                   only : radiation_field_t
+    use tuvx_spherical_geometry,       only : spherical_geometry_t
     use tuvx_test_utils,               only : check_values
 
     type(heating_rates_t),      pointer :: heating_rates
@@ -39,8 +42,16 @@ contains
     type(config_t) :: config, sub_config, reactions_config
     type(string_t), allocatable :: labels(:)
     character, allocatable :: buffer(:)
-    integer :: pos, pack_size
+    integer :: pos, pack_size, i_height, i_wavelength
     integer, parameter :: comm = MPI_COMM_WORLD
+    real(dk), parameter :: hc = 6.62608e-34_dk * 2.9979e8_dk / 1.e-9_dk
+    real(dk) :: bde(6,2), actinic_flux(5,6), etfl(6)
+    real(dk) :: wc(6) = (/ 425.0_dk, 475.0_dk, 525.0_dk, 575.0_dk, 625.0_dk,  &
+                           675.0_dk /)
+    type(radiation_field_t) :: radiation_field
+    real(dk) :: calculated_rates(5,2), expected_rates(5,2)
+    type(la_sr_bands_t) :: la_srb
+    type(spherical_geometry_t) :: spherical_geometry
 
     call config%from_file( "test/data/heating_rates.json" )
     call config%get( "grids", sub_config, Iam )
@@ -77,6 +88,44 @@ contains
     call assert( 152892147, size(labels) == 2 )
     call assert( 437272930, labels(1) == "jfoo" )
     call assert( 884640776, labels(2) == "jbaz" )
+
+    ! check bond dissociation energies
+    call assert( 613305591, size( heating_rates%heating_parameters_ ) == 2 )
+    bde(:,1) = max( 0.0_dk, hc * ( 2.0_dk - wc(:) ) / ( 2.0_dk * wc(:) ) )
+    call check_values( heating_rates%heating_parameters_(1)%energy_,          &
+                       bde(:,1), 1.0e-4_dk )
+    bde(:,2) = max( 0.0_dk, hc * ( 3000.0_dk - wc(:) ) / ( 3000.0_dk * wc(:) ) )
+    call check_values( heating_rates%heating_parameters_(2)%energy_,          &
+                       bde(:,2), 1.0e-4_dk )
+
+    ! check calculated heating rates
+    calculated_rates(:,:) = 0.0_dk
+    allocate( radiation_field%fdr_(5,6), radiation_field%fdn_(5,6),           &
+              radiation_field%fup_(5,6) )
+    do i_wavelength = 1, 6
+      etfl(i_wavelength) = 0.5_dk * ( 1.0e3_dk * 10.0_dk**i_wavelength +      &
+                                      1.0e4_dk * 10.0_dk**i_wavelength )
+    end do
+    do i_height = 1, 5
+      do i_wavelength = 1, 6
+        radiation_field%fdr_( i_height, i_wavelength ) =                      &
+            1.0_dk * i_height * i_wavelength
+        radiation_field%fdn_( i_height, i_wavelength ) =                      &
+            2.0_dk * i_height * i_wavelength
+        radiation_field%fup_( i_height, i_wavelength ) =                      &
+            3.0_dk * i_height * i_wavelength
+        actinic_flux( i_height, i_wavelength ) =                              &
+            6.0_dk * i_height * i_wavelength * etfl( i_wavelength )
+        expected_rates( i_height, 1 ) =                                       &
+          dot_product( actinic_flux(i_height,:), bde(:,1) * 12.3_dk * 0.75_dk )
+        expected_rates( i_height, 2 ) = 1.1_dk *                              &
+          dot_product( actinic_flux(i_height,:), bde(:,2) * 78.9_dk * 0.5_dk )
+      end do
+    end do
+    call heating_rates%get( la_srb, spherical_geometry, grids, profiles,      &
+                            radiation_field, calculated_rates )
+
+    call check_values( calculated_rates, expected_rates, 1.0e-4_dk )
 
     deallocate( grids )
     deallocate( profiles )

--- a/test/unit/heating_rates.F90
+++ b/test/unit/heating_rates.F90
@@ -1,0 +1,89 @@
+! Copyright (C) 2024 National Center for Atmospheric Research
+! SPDX-License-Identifier: Apache-2.0
+!
+program test_heating_rates
+
+  use musica_mpi,                      only : musica_mpi_init,                &
+                                              musica_mpi_finalize
+  use tuvx_heating_rates
+
+  implicit none
+
+  call musica_mpi_init( )
+  call test_heating_rates_t( )
+  call musica_mpi_finalize( )
+
+contains
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  !> @brief Test the heating rates
+  subroutine test_heating_rates_t( )
+
+    use musica_assert,                 only : assert
+    use musica_config,                 only : config_t
+    use musica_constants,              only : dk => musica_dk
+    use musica_mpi,                    only : musica_mpi_bcast,               &
+                                              musica_mpi_rank,                &
+                                              MPI_COMM_WORLD
+    use musica_string,                 only : string_t
+    use tuvx_grid_warehouse,           only : grid_warehouse_t
+    use tuvx_profile_warehouse,        only : profile_warehouse_t
+    use tuvx_test_utils,               only : check_values
+
+    type(heating_rates_t),      pointer :: heating_rates
+    class(grid_warehouse_t),    pointer :: grids
+    class(profile_warehouse_t), pointer :: profiles
+
+    character(len=*), parameter :: Iam = "heating_rates_t tests"
+    type(config_t) :: config, sub_config, reactions_config
+    type(string_t), allocatable :: labels(:)
+    character, allocatable :: buffer(:)
+    integer :: pos, pack_size
+    integer, parameter :: comm = MPI_COMM_WORLD
+
+    call config%from_file( "test/data/heating_rates.json" )
+    call config%get( "grids", sub_config, Iam )
+    grids => grid_warehouse_t( sub_config )
+    call config%get( "profiles", sub_config, Iam )
+    profiles => profile_warehouse_t( sub_config, grids )
+
+    if( musica_mpi_rank( comm ) == 0 ) then
+      call config%get( "reactions", reactions_config, Iam )
+      call sub_config%empty( )
+      call sub_config%add( "reactions", reactions_config, Iam )
+      heating_rates => heating_rates_t( sub_config, grids, profiles )
+      pack_size = heating_rates%pack_size( comm )
+      allocate( buffer( pack_size ) )
+      pos = 0
+      call heating_rates%mpi_pack( buffer, pos, comm )
+      call assert( 534250649, pos <= pack_size )
+    end if
+
+    call musica_mpi_bcast( pack_size, comm )
+    if( musica_mpi_rank( comm ) .ne. 0 ) allocate( buffer( pack_size ) )
+    call musica_mpi_bcast( buffer, comm )
+
+    if( musica_mpi_rank( comm ) .ne. 0 ) then
+      pos = 0
+      allocate( heating_rates )
+      call heating_rates%mpi_unpack( buffer, pos, comm )
+      call assert( 192483602, pos <= pack_size )
+    end if
+    deallocate( buffer )
+
+    ! check labels
+    labels = heating_rates%labels( )
+    call assert( 152892147, size(labels) == 2 )
+    call assert( 437272930, labels(1) == "jfoo" )
+    call assert( 884640776, labels(2) == "jbaz" )
+
+    deallocate( grids )
+    deallocate( profiles )
+    deallocate( heating_rates )
+
+  end subroutine test_heating_rates_t
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+end program test_heating_rates


### PR DESCRIPTION
closes #47 

Heating rate calculations can be included by adding:
```
"heating": { "energy term" : 12.3 }
```
to the configuration of a photolysis reaction, where 12.3 is the constants needed to calculate the wavelength-dependent bond dissociation energy. API updates follow the pattern used for photolysis rate constants and dose rates