### PR TITLE
fix bug with O2 heating rates

### DIFF
--- a/src/heating_rates.F90
+++ b/src/heating_rates.F90
@@ -99,6 +99,7 @@ contains
 
     character(len=*), parameter :: Iam = 'heating rates constructor'
     type(config_t) :: reaction_set, reaction_config, heating_config
+    type(config_t) :: cross_section_config
     class(iterator_t), pointer :: iter
     type(string_t) :: label
     type(string_t) :: required_keys(1), optional_keys(1)
@@ -121,7 +122,6 @@ contains
 
     ! iterate over photolysis reactions looking for those with
     ! heating rate parameters
-    allocate( this%o2_rate_indices_( 0 ) )
     call config%get( "reactions", reaction_set, Iam )
     iter => reaction_set%get_iterator( )
     n_hr = 0
@@ -131,12 +131,14 @@ contains
       call reaction_config%get( "heating", heating_config, Iam, found = found )
       if( found ) then
         n_hr = n_hr + 1
-        call reaction_config%get( "apply O2 bands", do_apply_bands, Iam,      &
+        call reaction_config%get( "cross section", cross_section_config, Iam )
+        call cross_section_config%get( "apply O2 bands", do_apply_bands, Iam, &
                                   default = .false. )
         if( do_apply_bands ) n_O2 = n_O2 + 1
       end if
     end do
     allocate( this%heating_parameters_( n_hr ) )
+    allocate( this%o2_rate_indices_( n_O2 ) )
     call iter%reset( )
     i_hr = 0
     i_O2 = 0
@@ -148,7 +150,8 @@ contains
         call reaction_config%get( "name", label, Iam )
         this%heating_parameters_( i_hr ) =                                    &
           heating_parameters_constructor( reaction_config, grids, profiles )
-        call reaction_config%get( "apply O2 bands", do_apply_bands, Iam,      &
+        call reaction_config%get( "cross section", cross_section_config, Iam )
+        call cross_section_config%get( "apply O2 bands", do_apply_bands, Iam, &
                                   default = .false. )
         if( do_apply_bands ) then
           i_O2 = i_O2 + 1

--- a/test/data/heating_rates.json
+++ b/test/data/heating_rates.json
@@ -70,6 +70,7 @@
       "name": "jbar",
       "cross section": {
         "type": "base",
+        "apply O2 bands": true,
         "data": {
           "default value": 45.6
         }
@@ -83,6 +84,7 @@
       "name": "jbaz",
       "cross section": {
         "type": "base",
+        "apply O2 bands": false,
         "data": {
           "default value": 78.9
         }
@@ -94,6 +96,24 @@
       "scaling factor": 1.1,
       "heating": {
         "energy term": 3000.0
+      }
+    },
+    {
+      "name": "jqux",
+      "cross section": {
+        "type": "base",
+        "apply O2 bands": true,
+        "data": {
+          "default value": 101.1
+        }
+      },
+      "quantum yield": {
+        "type": "base",
+        "constant value": 0.3
+      },
+      "scaling factor": 1.12,
+      "heating": {
+        "energy term": 3100.0
       }
     }
   ]


### PR DESCRIPTION
Fixes a bug that was preventing O2 bands from being correctly applied to heating rates when the "apply O2 bands" option was selected.