### PR TITLE
Catch a link error on Ubuntu 23.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,15 @@ add_executable(tuv-x src/tuvx.F90 version.F90)
 set_target_properties(tuv-x
   PROPERTIES
   LINKER_LANGUAGE Fortran
+  POSITION_INDEPENDENT_CODE ON
 )
+
+if(NOT BUILD_SHARED_LIBS)
+  set_target_properties(tuv-x
+    PROPERTIES
+    POSITION_INDEPENDENT_CODE ON
+  )
+endif()
 
 target_link_libraries(tuv-x 
   PUBLIC 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,6 @@ add_executable(tuv-x src/tuvx.F90 version.F90)
 set_target_properties(tuv-x
   PROPERTIES
   LINKER_LANGUAGE Fortran
-  POSITION_INDEPENDENT_CODE ON
 )
 
 if(NOT BUILD_SHARED_LIBS)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,6 +32,8 @@ if(BLAS_LIBRARIES)
     PRIVATE
       ${BLAS_LIBRARIES}
   )
+else()
+  message(FATAL_ERROR "BLAS Libraries not found.")
 endif()
 
 if(LAPACK_LIBRARIES)
@@ -39,6 +41,8 @@ if(LAPACK_LIBRARIES)
   PRIVATE
     ${LAPACK_LIBRARIES}
   )
+else()
+  message(FATAL_ERROR "LAPACK libraries not found.")
 endif()
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,15 +18,29 @@ target_include_directories(tuvx_object
     $<INSTALL_INTERFACE:${INSTALL_INCLUDE_DIR}>
 )
 
+message(STATUS "blas libraries: ${BLAS_LIBRARIES}")
 message(STATUS "lapack libraries: ${LAPACK_LIBRARIES}")
 
 target_link_libraries(tuvx_object 
   PRIVATE
     PkgConfig::netcdff
     yaml-cpp::yaml-cpp
-    ${BLAS_LIBRARIES}
-    ${LAPACK_LIBRARIES}
 )
+
+if(BLAS_LIBRARIES)
+  target_link_libraries(tuvx_object
+    PRIVATE
+      ${BLAS_LIBRARIES}
+  )
+endif()
+
+if(LAPACK_LIBRARIES)
+  target_link_libraries(tuvx_object
+  PRIVATE
+    ${LAPACK_LIBRARIES}
+  )
+endif()
+
 
 # tuvx library
 add_library(tuvx $<TARGET_OBJECTS:tuvx_object>)

--- a/test/unit/util/CMakeLists.txt
+++ b/test/unit/util/CMakeLists.txt
@@ -13,6 +13,8 @@ add_executable(util_assert_failure assert.F90)
 set_target_properties(util_assert_failure PROPERTIES LINKER_LANGUAGE Fortran)
 add_std_test_script(util_assert_failure assert.sh)
 
+set_tests_properties(util_assert_failure PROPERTIES WILL_FAIL TRUE)
+
 create_standard_test(NAME util_config SOURCES config.F90)
 
 create_standard_test(NAME util_map SOURCES map.F90)

--- a/test/unit/util/CMakeLists.txt
+++ b/test/unit/util/CMakeLists.txt
@@ -13,8 +13,6 @@ add_executable(util_assert_failure assert.F90)
 set_target_properties(util_assert_failure PROPERTIES LINKER_LANGUAGE Fortran)
 add_std_test_script(util_assert_failure assert.sh)
 
-set_tests_properties(util_assert_failure PROPERTIES WILL_FAIL TRUE)
-
 create_standard_test(NAME util_config SOURCES config.F90)
 
 create_standard_test(NAME util_map SOURCES map.F90)


### PR DESCRIPTION
I encountered an issue when compiling `tuv-x` on Ubuntu linux.  This issue manifested as a link failure, `-lFALSE` not found. The issue were missing libblas and liblapack libraries.  Adding a stopgap measure to indicate when this is the issue. 

Also added position-independent code flag if building statically. 