### PR TITLE
Add verbose fetchcontent output when FETCHCONTENT_QUIET is set to false

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -52,6 +52,7 @@ FetchContent_Declare(
   yaml-cpp
   GIT_REPOSITORY https://github.com/jbeder/yaml-cpp/
   GIT_TAG 0.8.0
+  GIT_PROGRESS NOT ${FETCHCONTENT_QUIET}
 )
 FetchContent_MakeAvailable(yaml-cpp)
 


### PR DESCRIPTION
Propagates the changes discussed in https://github.com/NCAR/musica/pull/113, re: allowing verbose `fetchcontent` output useful, perhaps, to those on limited bandwidth.  When fetchcontent happens silently, `cmake [srcdir]` can appear to hang or, at the very least, be taking an undetermined amount of time. 