### PR TITLE
Fix Ubuntu action

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -13,8 +13,6 @@ jobs:
     strategy:
       matrix:
         gcc_version: [12, 13, 14]
-    env:
-      FC: gfortran-${{ matrix.gcc_version }}
     steps:
     - uses: actions/checkout@v3
       with:
@@ -22,7 +20,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y libnetcdf-dev netcdf-bin libnetcdff-dev
+        sudo apt-get install -y libnetcdf-dev netcdf-bin libnetcdff-dev liblapack-dev
         sudo apt-get install -y python3-numpy python3-scipy
     - name: Run Cmake 
       run: cmake -S . -B build 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -24,7 +24,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y libnetcdf-dev netcdf-bin libnetcdff-dev
     - name: Install python dependencies
-      run: pip install numpy scipy
+      run: pip install --user numpy scipy
     - name: Run Cmake 
       run: cmake -S . -B build 
     - name: Build

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -13,8 +13,6 @@ jobs:
     strategy:
       matrix:
         gcc_version: [11, 12, 13]
-    env:
-      FC: gfortran-${{ matrix.gcc_version }}
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -8,11 +8,13 @@ concurrency:
 
 jobs:
   gcc:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     strategy:
       matrix:
-        gcc_version: [11, 12, 13]
+        gcc_version: [12, 13, 14]
+    env:
+      FC: gfortran-${{ matrix.gcc_version }}
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -13,6 +13,10 @@ jobs:
     strategy:
       matrix:
         gcc_version: [12, 13, 14]
+    env:
+      CXX: g++-${{ matrix.gcc_version }}
+      CC: gcc-${{ matrix.gcc_version }}
+      FC: gfortran-${{ matrix.gcc_version }}
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -23,8 +23,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y libnetcdf-dev netcdf-bin libnetcdff-dev
-    - name: Install python dependencies
-      run: pip install --user numpy scipy
+        sudo apt-get install -y python3-numpy python3-scipy
     - name: Run Cmake 
       run: cmake -S . -B build 
     - name: Build


### PR DESCRIPTION
The `ubuntu-latest` image (22.04) used by GH actions appears to have recently removed GNU 13 compilers as an option (https://github.com/actions/runner-images/commit/877807370206567253a2fbc0b76f95b5e69d85cc)

This PR updates the action to use `ubuntu-24.04` with GNU 12, 13, and 14