### PR TITLE
Link netCDF-C via pkgconfig

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -43,7 +43,13 @@ endif()
 # NetCDF library
 
 find_package(PkgConfig REQUIRED)
+
+
+
 pkg_check_modules(netcdff IMPORTED_TARGET REQUIRED netcdf-fortran)
+pkg_check_modules(netcdfc IMPORTED_TARGET REQUIRED netcdf)
+
+
 
 ################################################################################
 # yaml-cpp

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -52,6 +52,7 @@ FetchContent_Declare(
   yaml-cpp
   GIT_REPOSITORY https://github.com/jbeder/yaml-cpp/
   GIT_TAG 0.8.0
+  GIT_PROGRESS NOT ${FETCHCONTENT_QUIET}
 )
 FetchContent_MakeAvailable(yaml-cpp)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,8 +23,8 @@ message(STATUS "lapack libraries: ${LAPACK_LIBRARIES}")
 
 target_link_libraries(tuvx_object 
   PRIVATE
-    PkgConfig::netcdfc
     PkgConfig::netcdff
+    PkgConfig::netcdfc
     yaml-cpp::yaml-cpp
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,6 +23,7 @@ message(STATUS "lapack libraries: ${LAPACK_LIBRARIES}")
 
 target_link_libraries(tuvx_object 
   PRIVATE
+    PkgConfig::netcdfc
     PkgConfig::netcdff
     yaml-cpp::yaml-cpp
 )


### PR DESCRIPTION
When linking against static `netcdf-fortran`, there are many unresolved symbols from the netcdf-c library.  This finds and links against the C library and resolves the issue, at least in my testing. 