### PR TITLE
added BLAS library specification in build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,10 @@ The full example uses data files from the `data` directory, which is why you nee
 ```
 cd /output
 cp -r /build/data .
-tuv-x /build/examples/full_config.json
+# to use the standalone tool
+./tuv-x examples/tuv_5_4.json
+# or 
+./tuv-x examples/ts1_tsmlt.json
 ```
 
 Now, in your downloads folder, you should have to nc files, `photolysis_rate_constants.nc` and `dose_rates.nc`.
@@ -93,8 +96,12 @@ make -j 8
 
 You will now have a runnable exectubable for `tuv-x` and the tests in the build directory.
 
-`./tuv-x examples/full_config.json`.
-
+```
+# to use the standalone tool
+./tuv-x examples/tuv_5_4.json
+# or 
+./tuv-x examples/ts1_tsmlt.json
+```
 Inspect the output file `photolysis_rate_constants.nc` to see the results!
 
 ## Install

--- a/etc/derecho/README.md
+++ b/etc/derecho/README.md
@@ -45,6 +45,8 @@ make test
 
 ```
 cd $TUVX_HOME/tuv-x/build
-./tuv-x examples/full_config.json
+./tuv-x examples/tuv_5_4.json
+# or 
+./tuv-x examples/ts1_tsmlt.json
 ```
 

--- a/etc/derecho/README.md
+++ b/etc/derecho/README.md
@@ -1,5 +1,6 @@
 # Building TUV-x on Derecho 
 
+
 ## Get the source code
 
 - Copy the build script you wish to use from this folder to GLADE.
@@ -22,6 +23,7 @@ export TUVX_HOME=/path/to/my-tuvx-build
 ## Build TUV-x
 
 Replace `/path/to/build_tuvx_derecho_X.sh` with the path to the build script you copied to GLADE, in the following:
+> NOTE: Some test cases fail to build with the intel compiler.   
 
 ```
 cd $TUVX_HOME

--- a/etc/derecho/build_tuvx_derecho_gnu.sh
+++ b/etc/derecho/build_tuvx_derecho_gnu.sh
@@ -24,7 +24,9 @@ if [[ ! -d "${TUVX_HOME}" ]]; then
 fi
 
 # download and build TUV-X
-echo "Building TUV-x"
+echo "Downloading and Building TUV-x"
+cd ${TUVX_HOME}
+git clone git@github.com:NCAR/tuv-x.git
 cd tuv-x
 mkdir build
 cd build

--- a/etc/derecho/build_tuvx_derecho_gnu.sh
+++ b/etc/derecho/build_tuvx_derecho_gnu.sh
@@ -24,8 +24,7 @@ if [[ ! -d "${TUVX_HOME}" ]]; then
 fi
 
 # download and build TUV-X
-cd ${TUVX_HOME}
-git clone git@github.com:NCAR/tuv-x.git
+echo "Building TUV-x"
 cd tuv-x
 mkdir build
 cd build

--- a/etc/derecho/build_tuvx_derecho_gnu.sh
+++ b/etc/derecho/build_tuvx_derecho_gnu.sh
@@ -3,7 +3,6 @@
 # The TUVX_HOME environment variable must be set to the directory to build TUV-x
 # in prior to calling this script
 
-
 module purge
 module load ncarenv/23.09
 module load craype/2.7.20
@@ -12,6 +11,7 @@ module load cray-libsci/23.02.1.1
 module load netcdf/4.9.2
 module load ncarcompilers/1.0.0
 module load cmake/3.26.3
+
 
 if [[ -z "${TUVX_HOME}" ]]; then
   echo "You must set the TUVX_HOME environment variable to the directory where TUV-x should be build."
@@ -23,29 +23,11 @@ if [[ ! -d "${TUVX_HOME}" ]]; then
   return
 fi
 
-echo "Building JSON Fortran"
-
-# get & build the source code of JSON Fortran
-
-cd ${TUVX_HOME}
-curl -LO https://github.com/jacobwilliams/json-fortran/archive/8.3.0.tar.gz
-tar -zxvf 8.3.0.tar.gz
-cd json-fortran-8.3.0
-mkdir build
-cd build
-INSTALL_DIR=$TUVX_HOME/json-fortran-8.3.0
-cmake -D SKIP_DOC_GEN:BOOL=TRUE -D CMAKE_INSTALL_PREFIX=$INSTALL_DIR ..
-make install
-
-echo "Building TUV-x"
-
-# get & build the source code of TUV-x
-
+# download and build TUV-X
 cd ${TUVX_HOME}
 git clone git@github.com:NCAR/tuv-x.git
 cd tuv-x
 mkdir build
 cd build
-export JSON_FORTRAN_HOME=$INSTALL_DIR/jsonfortran-gnu-8.3.0
-cmake -D CMAKE_BUILD_TYPE=release -D TUVX_ENABLE_MEMCHECK=OFF -D LAPACK_LIBRARIES=-lsci_gnu ..   
+cmake -D CMAKE_BUILD_TYPE=release -D TUVX_ENABLE_MEMCHECK=OFF -D LAPACK_LIBRARIES=-lsci_gnu -D BLAS_LIBRARIES=-lsci_gnu ..   
 make -j 8

--- a/etc/derecho/build_tuvx_derecho_intel.sh
+++ b/etc/derecho/build_tuvx_derecho_intel.sh
@@ -22,7 +22,7 @@ if [[ ! -d "${TUVX_HOME}" ]]; then
 fi
 
 # get & build the source code of TUV-x
-echo "Building TUV-x"
+echo "Downloading and Building TUV-x"
 cd ${TUVX_HOME}
 git clone git@github.com:NCAR/tuv-x.git
 cd tuv-x

--- a/etc/derecho/build_tuvx_derecho_intel.sh
+++ b/etc/derecho/build_tuvx_derecho_intel.sh
@@ -21,24 +21,7 @@ if [[ ! -d "${TUVX_HOME}" ]]; then
   return
 fi
 
-echo "Building JSON Fortran"
-
-# get & build the source code of JSON Fortran
-
-cd ${TUVX_HOME}
-curl -LO https://github.com/jacobwilliams/json-fortran/archive/8.3.0.tar.gz
-tar -zxvf 8.3.0.tar.gz
-cd json-fortran-8.3.0
-mkdir build
-cd build
-INSTALL_DIR=$TUVX_HOME/json-fortran-8.3.0
-cmake -D SKIP_DOC_GEN:BOOL=TRUE -D CMAKE_INSTALL_PREFIX=$INSTALL_DIR ..
-make install
-
-echo "Building TUV-x"
-
 # get & build the source code of TUV-x
-
 cd ${TUVX_HOME}
 git clone git@github.com:NCAR/tuv-x.git
 cd tuv-x

--- a/etc/derecho/build_tuvx_derecho_intel.sh
+++ b/etc/derecho/build_tuvx_derecho_intel.sh
@@ -22,6 +22,7 @@ if [[ ! -d "${TUVX_HOME}" ]]; then
 fi
 
 # get & build the source code of TUV-x
+echo "Building TUV-x"
 cd ${TUVX_HOME}
 git clone git@github.com:NCAR/tuv-x.git
 cd tuv-x


### PR DESCRIPTION
1. Modified the cmake command to add BLAS libraries to the build tree in the GNU compiler build script.
2. Removed Fortran JSON library installation from the build scripts.
3. Modified README.md with correct example JSON configurations.

closes #82 
