### PR TITLE
Make updater pointers public

### DIFF
--- a/src/grids/from_host.F90
+++ b/src/grids/from_host.F90
@@ -24,9 +24,6 @@ module tuvx_grid_from_host
   end interface grid_from_host_t
 
   type :: grid_updater_t
-#ifndef MUSICA_IS_NAG_COMPILER
-    private
-#endif
     ! updater for `grid_from_host_t` grids
     class(grid_from_host_t), pointer :: grid_ => null( )
   contains

--- a/src/profiles/from_host.F90
+++ b/src/profiles/from_host.F90
@@ -24,9 +24,6 @@ module tuvx_profile_from_host
   end interface profile_from_host_t
 
   type :: profile_updater_t
-#ifndef MUSICA_IS_NAG_COMPILER
-    private
-#endif
     ! updater for `profile_from_host_t` profiles
     class(profile_from_host_t), pointer :: profile_ => null( )
   contains

--- a/src/radiative_transfer/radiators/from_host.F90
+++ b/src/radiative_transfer/radiators/from_host.F90
@@ -26,9 +26,6 @@ module tuvx_radiator_from_host
   end interface radiator_from_host_t
 
   type :: radiator_updater_t
-#ifndef MUSICA_IS_NAG_COMPILER
-    private
-#endif
     ! updater for `radiator_from_host_t` radiators
     class(radiator_from_host_t), pointer :: radiator_ => null( )
   contains


### PR DESCRIPTION
Changes the grid, profile, and radiator updaters to make their pointer data members public. This is so we can use the pointer in the MUSICA library to access the current grid, profile, and radiator data instead of making a bunch of getter functions.