### PR TITLE
remove overloaded copy assign for strings

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -17,7 +17,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        gcc_version: [12, 13, 14]
+        gcc_version: [12, 14]
     env:
       CXX: g++-${{ matrix.gcc_version }}
       CC: gcc-${{ matrix.gcc_version }}

--- a/src/util/string.F90
+++ b/src/util/string.F90
@@ -29,7 +29,6 @@ module musica_string
     procedure, private, pass(to) :: string_assign_real
     procedure, private, pass(to) :: string_assign_double
     procedure, private, pass(to) :: string_assign_logical
-    procedure, private, pass(from) :: string_assign_string
     procedure, private, pass(from) :: char_assign_string
     procedure, private, pass(from) :: real_assign_string
     procedure, private, pass(from) :: double_assign_string
@@ -37,7 +36,7 @@ module musica_string
     procedure, private, pass(from) :: logical_assign_string
     generic :: assignment(=) => string_assign_char, string_assign_int,        &
                                 string_assign_real, string_assign_double,     &
-                                string_assign_logical, string_assign_string,  &
+                                string_assign_logical, &
                                 char_assign_string, real_assign_string,       &
                                 double_assign_string, int_assign_string,      &
                                 logical_assign_string
@@ -225,24 +224,6 @@ contains
     end if
 
   end subroutine string_assign_logical
-
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-  !> Assign a string from a string
-  subroutine string_assign_string( to, from )
-
-    !> String to assign
-    type(string_t), intent(inout) :: to
-    !> String to assign from
-    class(string_t), intent(in) :: from
-
-    if( .not. allocated( from%val_ ) ) then
-      if( allocated( to%val_ ) ) deallocate( to%val_ )
-      return
-    end if
-    to%val_ = from%val_
-
-  end subroutine string_assign_string
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 


### PR DESCRIPTION
The overloaded assignment operator for strings is not needed because the data members are `public`, and this was causing problems with temporary RHS variables in assignments not being deallocated.

This PR also drops support for gcc13 on Ubuntu because of a gfortran Internal Compiler Error that appears to have been fixed in gcc14