### PR TITLE
Wrap diagnostic output with if block

### DIFF
--- a/src/photolysis_rates.F90
+++ b/src/photolysis_rates.F90
@@ -380,10 +380,13 @@ rate_loop:                                                                    &
       if( allocated( quantum_yield ) ) deallocate( quantum_yield )
     end do rate_loop
 
-    call diagout( 'annotatedjlabels.new', this%handles_,                      &
-      this%enable_diagnostics_ )
-    call diagout( 'xsqy.'//file_tag//'.new', xsqyWrk, this%enable_diagnostics_ )
-
+    if (this%enable_diagnostics_) then
+    associate( enable => this%enable_diagnostics_ )
+      call diagout( 'annotatedjlabels.new', this%handles_, enable )
+      call diagout( 'xsqy.'//file_tag//'.new', xsqyWrk, enable )
+    end associate
+    end if
+    
     deallocate( zGrid )
     deallocate( lambdaGrid )
     deallocate( etfl )


### PR DESCRIPTION
Adds a conditional block around diagnostic output in the photolysis rate calculation function. This is to prevent some unexplained memory leaks when not outputting diagnostics