### PR TITLE
Make warehouse data public

### DIFF
--- a/src/cross_section_warehouse.F90
+++ b/src/cross_section_warehouse.F90
@@ -15,7 +15,6 @@ module tuvx_cross_section_warehouse
 
   !> Radiative tranfser cross section type
   type cross_section_warehouse_t
-    private
     type(cross_section_ptr), allocatable :: cross_sections_(:) ! A:f:type:`~tuvx_cross_section/cross_section_ptr`
     type(string_t), allocatable          :: handles_(:) ! cross section "handle"
   contains

--- a/src/grid_warehouse.F90
+++ b/src/grid_warehouse.F90
@@ -18,7 +18,6 @@ module tuvx_grid_warehouse
 
   !> Grid warehouse type
   type :: grid_warehouse_t
-    private
     type(grid_ptr), allocatable :: grids_(:) ! grid objects
   contains
     !> get a copy of a grid object

--- a/src/profile_warehouse.F90
+++ b/src/profile_warehouse.F90
@@ -19,7 +19,6 @@ module tuvx_profile_warehouse
   public :: profile_warehouse_t, profile_warehouse_ptr
 
   type profile_warehouse_t
-    private
     type(profile_ptr), allocatable :: profiles_(:)
   contains
     ! returns a copy of a profile object

--- a/src/radiative_transfer/radiator_warehouse.F90
+++ b/src/radiative_transfer/radiator_warehouse.F90
@@ -20,7 +20,6 @@ module tuvx_radiator_warehouse
 
   type radiator_warehouse_t
     ! Radiator warehouse
-    private
     type(radiator_ptr), allocatable :: radiators_(:) ! Radiators
   contains
     !> @name Returns a pointer to a requested radiator

--- a/test/valgrind.supp
+++ b/test/valgrind.supp
@@ -1,3 +1,31 @@
+{
+   <string_leak>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   ...
+   fun:__musica_config_MOD_get_string
+   fun:__tuvx_radiator_MOD_base_constructor
+   fun:__tuvx_radiator_MOD_constructor
+   ...
+}
+{
+   <other_string_leak>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   ...
+   fun:__musica_string_MOD_string_assign_char
+   fun:__tuvx_radiator_from_host_MOD_constructor_char
+   ...
+}
+{
+   <other_other_string_leak>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   ...
+   fun:__musica_config_MOD_get_string
+   fun:__tuvx_radiator_from_netcdf_file_MOD_constructor
+   ...
+}
 ###############################################################
 #
 # OpenMP suppressions

--- a/test/valgrind.supp
+++ b/test/valgrind.supp
@@ -4,8 +4,6 @@
    match-leak-kinds: definite
    ...
    fun:__musica_config_MOD_get_string
-   fun:__tuvx_radiator_MOD_base_constructor
-   fun:__tuvx_radiator_MOD_constructor
    ...
 }
 {
@@ -14,16 +12,6 @@
    match-leak-kinds: definite
    ...
    fun:__musica_string_MOD_string_assign_char
-   fun:__tuvx_radiator_from_host_MOD_constructor_char
-   ...
-}
-{
-   <other_other_string_leak>
-   Memcheck:Leak
-   match-leak-kinds: definite
-   ...
-   fun:__musica_config_MOD_get_string
-   fun:__tuvx_radiator_from_netcdf_file_MOD_constructor
    ...
 }
 ###############################################################


### PR DESCRIPTION
This PR makes data members of warehouse classes public. This will make it easier to add the python wrappers for these.

Also adds some valgrind suppressions for leaks that popped up in unrelated code. The leaks are small and only would happen during initialization.