### PR TITLE
updating yaml-cpp tag, add recursive keyword to remove warning

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -17,7 +17,7 @@ jobs:
     continue-on-error: true 
     strategy:
       matrix:
-        gcc_version: [12, 13, 14]
+        gcc_version: [13, 14, 15]
         build_type: [Debug, Release]
     env:
       FC: gfortran-${{ matrix.gcc_version }}

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -57,7 +57,7 @@ pkg_check_modules(netcdfc IMPORTED_TARGET REQUIRED netcdf)
 FetchContent_Declare(
   yaml-cpp
   GIT_REPOSITORY https://github.com/jbeder/yaml-cpp/
-  GIT_TAG 28f93bdec6387d42332220afa9558060c8016795
+  GIT_TAG 65c1c270dbe7eec37b2df2531d7497c4eea79aee
   GIT_PROGRESS NOT
   FIND_PACKAGE_ARGS NAMES yaml-cpp
   ${FETCHCONTENT_QUIET})

--- a/src/util/config.F90
+++ b/src/util/config.F90
@@ -712,7 +712,7 @@ contains
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
   !> Gets an array of config_t objects
-  subroutine get_config_array( this, key, value, caller, default, found )
+  recursive subroutine get_config_array( this, key, value, caller, default, found )
 
     use musica_assert,                 only : assert, assert_msg
 
@@ -839,7 +839,7 @@ contains
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
   !> Adds a subset of configuration data
-  subroutine add_config( this, key, value, caller )
+  recursive subroutine add_config( this, key, value, caller )
 
     use musica_assert,                 only : assert_msg
 
@@ -1067,7 +1067,7 @@ contains
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
   !> Adds a config_t array to the configuration data
-  subroutine add_config_array( this, key, value, caller )
+  recursive subroutine add_config_array( this, key, value, caller )
 
     use musica_assert,                 only : assert_msg
 


### PR DESCRIPTION
This removes compiler warnings by updating the yaml-cpp tag and adding the `recursive` keyword to a fortran routine