### PR TITLE
add option to build cli

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ option(TUVX_ENABLE_COVERAGE "Enable code coverage output" OFF)
 option(TUVX_ENABLE_MEMCHECK "Enable memory checking in tests" OFF)
 option(TUVX_ENABLE_REGRESSION_TESTS "Enable regression tests" ON)
 option(TUVX_BUILD_DOCS "Build the documentation" OFF)
+option(TUVX_BUILD_CLI "Build the command line interface" ON)
 set(TUVX_MOD_DIR "${PROJECT_BINARY_DIR}/include" CACHE PATH "Directory to find Fortran module files during the build")
 set(TUVX_INSTALL_MOD_DIR "${INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}" CACHE PATH "Directory to install Fortran module files")
 set(TUVX_INSTALL_INCLUDE_DIR "${INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}" CACHE PATH "Directory to install include files")
@@ -83,42 +84,44 @@ include(cmake/dependencies.cmake)
 
 add_subdirectory(src)
 
-# add tuv-x standalone executable
-add_executable(tuv-x src/tuvx.F90)
+if(TUVX_BUILD_CLI)
+  # add tuv-x standalone executable
+  add_executable(tuv-x src/tuvx.F90)
 
-set_target_properties(tuv-x
-  PROPERTIES
-  LINKER_LANGUAGE Fortran
-)
-
-if(NOT BUILD_SHARED_LIBS)
   set_target_properties(tuv-x
     PROPERTIES
-    POSITION_INDEPENDENT_CODE ON
+    LINKER_LANGUAGE Fortran
   )
-endif()
 
-target_link_libraries(tuv-x 
-  PUBLIC 
-    musica::tuvx
-    yaml-cpp::yaml-cpp
-)
+  if(NOT BUILD_SHARED_LIBS)
+    set_target_properties(tuv-x
+      PROPERTIES
+      POSITION_INDEPENDENT_CODE ON
+    )
+  endif()
 
-target_include_directories(tuv-x
-  PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
-    $<INSTALL_INTERFACE:${TUVX_INSTALL_INCLUDE_DIR}>)
-
-if(TUVX_ENABLE_OPENMP)
-  target_link_libraries(tuv-x PUBLIC OpenMP::OpenMP_Fortran)
-endif()
-
-if(TUVX_ENABLE_LAPACK)
-  target_link_libraries(tuv-x
-  PUBLIC
-    ${LAPACK_LIBRARIES}
-    ${BLAS_LIBRARIES}
+  target_link_libraries(tuv-x 
+    PUBLIC 
+      musica::tuvx
+      yaml-cpp::yaml-cpp
   )
+
+  target_include_directories(tuv-x
+    PUBLIC
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
+      $<INSTALL_INTERFACE:${TUVX_INSTALL_INCLUDE_DIR}>)
+
+  if(TUVX_ENABLE_OPENMP)
+    target_link_libraries(tuv-x PUBLIC OpenMP::OpenMP_Fortran)
+  endif()
+
+  if(TUVX_ENABLE_LAPACK)
+    target_link_libraries(tuv-x
+    PUBLIC
+      ${LAPACK_LIBRARIES}
+      ${BLAS_LIBRARIES}
+    )
+  endif()
 endif()
 
 ################################################################################

--- a/packaging/CMakeLists.txt
+++ b/packaging/CMakeLists.txt
@@ -1,9 +1,20 @@
 include(CMakePackageConfigHelpers)
 
-# install the binary and static library
+if (TUVX_BUILD_CLI)
+  # install the binary
+  install(
+    TARGETS 
+      tuv-x
+    EXPORT 
+      tuvx_Exports
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  )
+endif()
+
+# install the static library
 install(
   TARGETS 
-   tuv-x tuvx tuvx_object
+   tuvx tuvx_object
   EXPORT 
     tuvx_Exports
   LIBRARY DESTINATION ${INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}


### PR DESCRIPTION
For some reason the tuv-x cli cannot be linked properly on izumi. But we don't need to build the cli for tuvx to work in cam, and also we can reduce build times a smidgeon by turning off the cli in musica