### PR TITLE
Appease nvhpc

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,11 +27,19 @@ jobs:
           - Dockerfile.mpi
           - Dockerfile.mpi.memcheck
           - Dockerfile.intel
+          - Dockerfile.nvhpc
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # this might remove tools that are actually needed,
+          # if set to "true" but frees about 6 GB
+          tool-cache: false
 
       - name: Build Docker image
         run: docker build -t tuvx -f docker/${{ matrix.dockerfile }} .

--- a/docker/Dockerfile.intel
+++ b/docker/Dockerfile.intel
@@ -53,7 +53,7 @@ RUN git clone https://github.com/Unidata/netcdf-fortran.git \
   && make -j 4 \
   && make install
 
-# Micm
+# Copy the tuvx code
 COPY . /tuvx/
 
 # build the library and run the tests

--- a/docker/Dockerfile.nvhpc
+++ b/docker/Dockerfile.nvhpc
@@ -1,0 +1,73 @@
+# nvidia rate limits requests. You can get around this by restarting docker if for 
+# some reason you have to build this image many times
+# https://stackoverflow.com/a/75757516/5217293
+#
+# Container versions, and sizes, can be found at https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nvhpc/tags
+#
+FROM nvcr.io/nvidia/nvhpc:25.7-devel-cuda12.9-ubuntu24.04
+
+RUN apt update \
+    && apt -y install \
+    curl \
+    gcc \
+    gdb \
+    gfortran \
+    git \
+    liblapack-dev \
+    libhdf5-dev \
+    make \
+    pkg-config \
+    python3 \
+    python3-numpy \
+    python3-pip \
+    python3-scipy \
+    valgrind \ 
+    vim \
+    && apt clean 
+
+ENV LD_LIBRARY_PATH=/usr/local/lib64
+
+# set compilers
+ENV CXX=nvc++
+ENV CC=nvc
+ENV FC=nvfortran
+
+# Download netcdf and netcdf-fortran and build and install them with intel
+RUN git clone https://github.com/Unidata/netcdf-c.git \
+  && cd netcdf-c \
+  && mkdir build \
+  && cd build \
+  && cmake -D CMAKE_BUILD_TYPE=release \
+    -D NETCDF_ENABLE_TESTS=OFF \
+    -D NETCDF_ENABLE_DAP=OFF \
+    -D NETCDF_ENABLE_DAP_REMOTE_TESTS=OFF \
+    -D CMAKE_INSTALL_PREFIX=/usr/local .. \
+  && make -j 4 \
+  && make install
+
+RUN git clone https://github.com/Unidata/netcdf-fortran.git \
+  && cd netcdf-fortran \
+  && mkdir build \
+  && cd build \
+  && cmake -D CMAKE_BUILD_TYPE=release \
+    -D ENABLE_TESTS=OFF \
+    -D CMAKE_INSTALL_PREFIX=/usr/local .. \
+  && make -j 4 \
+  && make install
+
+# Copy the tuvx code
+COPY . tuvx
+
+# build the tuv-x tool
+RUN cd /tuvx \
+      && mkdir build \
+      && cd build \
+      && cmake -D CMAKE_BUILD_TYPE=debug \
+               -D TUVX_INSTALL_INCLUDE_DIR=/usr/local/include \
+               -D TUVX_INSTALL_MOD_DIR=/usr/local/include \
+               -D TUVX_ENABLE_TESTS=ON \
+               -D TUVX_ENABLE_REGRESSION_TESTS=OFF \
+               .. \
+      && make install 
+
+WORKDIR /tuvx/build

--- a/docker/Dockerfile.nvhpc
+++ b/docker/Dockerfile.nvhpc
@@ -32,7 +32,7 @@ ENV CXX=nvc++
 ENV CC=nvc
 ENV FC=nvfortran
 
-# Download netcdf and netcdf-fortran and build and install them with intel
+# Download netcdf and netcdf-fortran and build and install them with nvhpc
 RUN git clone https://github.com/Unidata/netcdf-c.git \
   && cd netcdf-c \
   && mkdir build \

--- a/src/cross_sections/acetone-ch3co_ch3.F90
+++ b/src/cross_sections/acetone-ch3co_ch3.F90
@@ -94,6 +94,7 @@ contains
     integer                   :: nzdim, vertNdx
     real(dk)                      :: Tadj
     real(dk),         allocatable :: modelTemp(:)
+    real(dk),         allocatable :: wrkCrossSection(:,:)
     class(grid_t),    pointer     :: zGrid
     class(grid_t),    pointer     :: lambdaGrid
     class(profile_t), pointer     :: mdlTemperature
@@ -115,8 +116,8 @@ contains
       modelTemp = mdlTemperature%edge_val_
     endif
 
-    allocate( cross_section( lambdaGrid%ncells_, nzdim ) )
-    cross_section = rZERO
+    allocate( wrkCrossSection( lambdaGrid%ncells_, nzdim ) )
+    wrkCrossSection = rZERO
 
     call assert_msg(811958314, &
       size( this%cross_section_parms(1)%array, dim = 2 ) == 4, &
@@ -125,14 +126,14 @@ contains
     associate( coefficient => this%cross_section_parms(1)%array )
       do vertNdx = 1, nzdim
         Tadj = min( 298._dk, max( 235._dk, modelTemp( vertNdx ) ) )
-        cross_section(:,vertNdx) = coefficient(:,1)                           &
+        wrkCrossSection(:,vertNdx) = coefficient(:,1)                         &
                           * ( rONE + Tadj * ( coefficient(:,2)                &
                                               + Tadj*(coefficient(:,3)        &
                                               + Tadj*coefficient(:,4) ) ) )
       enddo
     end associate
 
-    cross_section = transpose( cross_section )
+    cross_section = transpose( wrkCrossSection )
 
     deallocate( zGrid )
     deallocate( lambdaGrid )

--- a/src/cross_sections/ccl4.F90
+++ b/src/cross_sections/ccl4.F90
@@ -89,6 +89,7 @@ contains
     real(dk)    :: Temp, Wpoly, w1
     integer :: lambdaNdx, vertNdx, nzdim
     real(dk),         allocatable :: modelTemp(:)
+    real(dk),         allocatable :: wrkCrossSection(:,:)
     class(grid_t),    pointer     :: zGrid
     class(grid_t),    pointer     :: lambdaGrid
     class(profile_t), pointer     :: mdlTemperature
@@ -110,8 +111,8 @@ contains
       modelTemp = mdlTemperature%edge_val_
     endif
 
-    allocate( cross_section( lambdaGrid%ncells_, nzdim ) )
-    cross_section = rZERO
+    allocate( wrkCrossSection( lambdaGrid%ncells_, nzdim ) )
+    wrkCrossSection = rZERO
 
     do vertNdx = 1,nzdim
       Temp = max( min( 300._dk, modelTemp( vertNdx ) ), 210._dk )
@@ -120,17 +121,17 @@ contains
         w1 = lambdaGrid%mid_( lambdaNdx )
         if( w1 > 194._dk .and. w1 < 250._dk ) then
           Wpoly = b0 + w1 * ( b1 + w1 * ( b2 + w1 * ( b3 + b4 * w1 ) ) )
-          cross_section( lambdaNdx, vertNdx ) =                               &
+          wrkCrossSection( lambdaNdx, vertNdx ) =                             &
               this%cross_section_parms(1)%array( lambdaNdx, 1 )               &
               * 10._dk**( Wpoly * Temp )
         else
-          cross_section( lambdaNdx, vertNdx ) =                               &
+          wrkCrossSection( lambdaNdx, vertNdx ) =                             &
               this%cross_section_parms(1)%array(lambdaNdx,1)
         endif
       enddo
     enddo
 
-    cross_section = transpose( cross_section )
+    cross_section = transpose( wrkCrossSection )
 
     deallocate( zGrid )
     deallocate( lambdaGrid )

--- a/src/cross_sections/cfc-11.F90
+++ b/src/cross_sections/cfc-11.F90
@@ -84,6 +84,7 @@ contains
     integer                   :: nzdim, vertNdx
     real(dk)                      :: Tadj
     real(dk),         allocatable :: modelTemp(:)
+    real(dk),         allocatable :: wrkCrossSection(:,:)
     class(grid_t),    pointer     :: zGrid
     class(grid_t),    pointer     :: lambdaGrid
     class(profile_t), pointer     :: mdlTemperature
@@ -105,17 +106,17 @@ contains
       modelTemp = mdlTemperature%edge_val_
     endif
 
-    allocate( cross_section( lambdaGrid%ncells_, nzdim ) )
-    cross_section = rZERO
+    allocate( wrkCrossSection( lambdaGrid%ncells_, nzdim ) )
+    wrkCrossSection = rZERO
 
     do vertNdx = 1, nzdim
       Tadj = 1.e-4_dk * ( modelTemp( vertNdx ) - 298._dk )
-      cross_section( :, vertNdx ) =                                           &
+      wrkCrossSection( :, vertNdx ) =                                         &
           this%cross_section_parms(1)%array(:,1)                              &
           * exp( ( lambdaGrid%mid_ - 184.9_dk ) * Tadj )
     enddo
 
-    cross_section = transpose( cross_section )
+    cross_section = transpose( wrkCrossSection )
 
     deallocate( zGrid )
     deallocate( lambdaGrid )

--- a/src/cross_sections/ch2o.F90
+++ b/src/cross_sections/ch2o.F90
@@ -85,6 +85,7 @@ contains
     integer :: nzdim, vertNdx
     real(dk)                      :: Tadj
     real(dk),         allocatable :: modelTemp(:)
+    real(dk),         allocatable :: wrkCrossSection(:,:)
     class(grid_t),    pointer     :: zGrid
     class(grid_t),    pointer     :: lambdaGrid
     class(profile_t), pointer     :: mdlTemperature
@@ -106,16 +107,17 @@ contains
       modelTemp = mdlTemperature%edge_val_
     endif
 
-    allocate( cross_section( lambdaGrid%ncells_, nzdim ) )
-    cross_section = rZERO
+    allocate( wrkCrossSection( lambdaGrid%ncells_, nzdim ) )
+    wrkCrossSection = rZERO
 
     do vertNdx = 1, nzdim
       Tadj = modelTemp( vertNdx ) - Thold
-      cross_section( :, vertNdx ) = this%cross_section_parms(1)%array(:,1)    &
+      wrkCrossSection( :, vertNdx ) =                                         &
+                                 this%cross_section_parms(1)%array(:,1)       &
                                + this%cross_section_parms(1)%array(:,2) * Tadj
     enddo
 
-    cross_section = transpose( cross_section )
+    cross_section = transpose( wrkCrossSection )
 
     deallocate( zGrid )
     deallocate( lambdaGrid )

--- a/src/cross_sections/ch3ono2-ch3o_no2.F90
+++ b/src/cross_sections/ch3ono2-ch3o_no2.F90
@@ -86,6 +86,7 @@ contains
     integer             :: nzdim
     integer             :: vertNdx
     real(dk),         allocatable :: modelTemp(:)
+    real(dk),         allocatable :: wrkCrossSection(:,:)
     class(grid_t),    pointer     :: zGrid
     class(grid_t),    pointer     :: lambdaGrid
     class(profile_t), pointer     :: mdlTemperature
@@ -107,16 +108,17 @@ contains
       modelTemp = mdlTemperature%edge_val_
     endif
 
-    allocate( cross_section( lambdaGrid%ncells_, nzdim ) )
-    cross_section = rZERO
+    allocate( wrkCrossSection( lambdaGrid%ncells_, nzdim ) )
+    wrkCrossSection = rZERO
 
     do vertNdx = 1, nzdim
       Temp = modelTemp( vertNdx ) - T0
-      cross_section( :, vertNdx ) = this%cross_section_parms(1)%array(:,1)    &
+      wrkCrossSection( :, vertNdx ) =                                         &
+                          this%cross_section_parms(1)%array(:,1)              &
                         * exp( this%cross_section_parms(1)%array(:,2) * Temp )
     enddo
 
-    cross_section = transpose( cross_section )
+    cross_section = transpose( wrkCrossSection )
 
     deallocate( zGrid )
     deallocate( lambdaGrid )

--- a/src/cross_sections/chbr3.F90
+++ b/src/cross_sections/chbr3.F90
@@ -90,6 +90,7 @@ contains
     integer  :: lambdaNdx, vertNdx, nzdim
     real(dk) :: Temp, lambda
     real(dk),         allocatable :: modelTemp(:)
+    real(dk),         allocatable :: wrkCrossSection(:,:)
     class(grid_t),    pointer     :: zGrid
     class(grid_t),    pointer     :: lambdaGrid
     class(profile_t), pointer     :: mdlTemperature
@@ -111,8 +112,8 @@ contains
       modelTemp = mdlTemperature%edge_val_
     endif
 
-    allocate( cross_section( lambdaGrid%ncells_, nzdim ) )
-    cross_section = rZERO
+    allocate( wrkCrossSection( lambdaGrid%ncells_, nzdim ) )
+    wrkCrossSection = rZERO
 
     do vertNdx = 1, nzdim
       Temp = modelTemp( vertNdx )
@@ -120,16 +121,16 @@ contains
         lambda = lambdaGrid%mid_( lambdaNdx )
         if( lambda > 290._dk .and. lambda < 340._dk .and.                     &
             Temp   > 210._dk .and. Temp   < 300._dk ) then
-          cross_section( lambdaNdx, vertNdx ) =                               &
+          wrkCrossSection( lambdaNdx, vertNdx ) =                             &
              exp( ( C0 - C1 * lambda ) * ( T0 - Temp ) - ( C2 + C3 * lambda ) )
         else
-          cross_section( lambdaNdx, vertNdx ) =                               &
+          wrkCrossSection( lambdaNdx, vertNdx ) =                             &
               this%cross_section_parms(1)%array( lambdaNdx, 1 )
         endif
       enddo
     enddo
 
-    cross_section = transpose( cross_section )
+    cross_section = transpose( wrkCrossSection )
 
     deallocate( zGrid )
     deallocate( lambdaGrid )

--- a/src/cross_sections/cl2-cl_cl.F90
+++ b/src/cross_sections/cl2-cl_cl.F90
@@ -81,6 +81,7 @@ contains
     integer :: lambdaNdx, vertNdx, nzdim
     real(dk)    :: aa, bb, bbsq, alpha, ex1, ex2
     real(dk),         allocatable :: modelTemp(:)
+    real(dk),         allocatable :: wrkCrossSection(:,:)
     class(grid_t),    pointer     :: lambdaGrid
     class(grid_t),    pointer     :: zGrid
     class(profile_t), pointer     :: temperature
@@ -102,7 +103,7 @@ contains
       modelTemp = temperature%edge_val_
     endif
 
-    allocate( cross_section( lambdaGrid%ncells_, zGrid%ncells_ + 1 ) )
+    allocate( wrkCrossSection( lambdaGrid%ncells_, zGrid%ncells_ + 1 ) )
 
     associate( wc => lambdaGrid%mid_ )
     do vertNdx = 1, nzdim
@@ -115,13 +116,13 @@ contains
                       * ( log( 329.5_dk / wc( lambdaNdx ) ) )**2 )
         ex2 =  .932_dk * exp( -91.5_dk * alpha                                &
                        * ( log( 406.5_dk / wc( lambdaNdx ) ) )**2 )
-        cross_section( lambdaNdx, vertNdx ) =                                 &
+        wrkCrossSection( lambdaNdx, vertNdx ) =                               &
             1.e-20_dk * sqrt( alpha ) * ( ex1 + ex2 )
       enddo
     enddo
     end associate
 
-    cross_section = transpose( cross_section )
+    cross_section = transpose( wrkCrossSection )
 
     deallocate( zGrid )
     deallocate( lambdaGrid )

--- a/src/cross_sections/clono2.F90
+++ b/src/cross_sections/clono2.F90
@@ -86,6 +86,7 @@ contains
     integer :: nzdim, vertNdx
     real(dk)    :: Tadj
     real(dk),         allocatable :: modelTemp(:)
+    real(dk),         allocatable :: wrkCrossSection(:,:)
     class(grid_t),    pointer     :: zGrid
     class(grid_t),    pointer     :: lambdaGrid
     class(profile_t), pointer     :: mdlTemperature
@@ -107,18 +108,18 @@ contains
       modelTemp = mdlTemperature%edge_val_
     endif
 
-    allocate( cross_section( lambdaGrid%ncells_, nzdim ) )
-    cross_section = rZERO
+    allocate( wrkCrossSection( lambdaGrid%ncells_, nzdim ) )
+    wrkCrossSection = rZERO
 
     associate( polyCoeff => this%cross_section_parms(1)%array )
     do vertNdx = 1, nzdim
       Tadj = modelTemp( vertNdx ) - Thold
-      cross_section( :, vertNdx ) = polyCoeff(:,1)                            &
+      wrkCrossSection( :, vertNdx ) = polyCoeff(:,1)                          &
           * ( rONE + Tadj * ( polyCoeff(:,2) + Tadj * polyCoeff(:,3) ) )
     enddo
     end associate
 
-    cross_section = transpose( cross_section )
+    cross_section = transpose( wrkCrossSection )
 
     deallocate( zGrid )
     deallocate( lambdaGrid )

--- a/src/cross_sections/h2o2-oh_oh.F90
+++ b/src/cross_sections/h2o2-oh_oh.F90
@@ -98,6 +98,7 @@ contains
         'h2o2+hv->oh+oh cross section calculate'
     integer    :: vertNdx, wNdx
     real(dk)       :: lambda, sumA, sumB, t, chi
+    real(dk),         allocatable :: wrkCrossSection(:,:)
     class(grid_t),    pointer :: zGrid
     class(grid_t),    pointer :: lambdaGrid
     class(profile_t), pointer :: temperature
@@ -107,7 +108,7 @@ contains
     temperature =>                                                            &
         profile_warehouse%get_profile( this%temperature_profile_ )
 
-    allocate( cross_section( lambdaGrid%ncells_, zGrid%ncells_ + 1 ) )
+    allocate( wrkCrossSection( lambdaGrid%ncells_, zGrid%ncells_ + 1 ) )
 
     associate( wl => lambdaGrid%edge_, wc => lambdaGrid%mid_ )
     do vertNdx = 1, zGrid%ncells_ + 1
@@ -123,17 +124,17 @@ contains
                   * lambda + B0
            t = min( max( temperature%edge_val_( vertNdx ), 200._dk ), 400._dk )
            chi = rONE / ( rONE + exp( -1265._dk / t ) )
-           cross_section( wNdx, vertNdx ) =                                   &
+           wrkCrossSection( wNdx, vertNdx ) =                                 &
                ( chi * sumA + ( rONE - chi ) * sumB ) * 1.E-21_dk
          else
-           cross_section( wNdx, vertNdx ) =                                   &
+           wrkCrossSection( wNdx, vertNdx ) =                                 &
                this%cross_section_parms(1)%array( wNdx, 1 )
          endif
       enddo
     enddo
     end associate
 
-    cross_section = transpose( cross_section )
+    cross_section = transpose( wrkCrossSection )
 
     deallocate( zGrid )
     deallocate( lambdaGrid )

--- a/src/cross_sections/hcfc.F90
+++ b/src/cross_sections/hcfc.F90
@@ -84,6 +84,7 @@ contains
     integer                   :: lambdaNdx, polyNdx
     real(dk)                      :: Tadj, sigma, uLambda
     real(dk),         allocatable :: modelTemp(:)
+    real(dk),         allocatable :: wrkCrossSection(:,:)
     class(grid_t),    pointer     :: zGrid
     class(grid_t),    pointer     :: lambdaGrid
     class(profile_t), pointer     :: mdlTemperature
@@ -105,8 +106,8 @@ contains
       modelTemp = mdlTemperature%edge_val_
     endif
 
-    allocate( cross_section( lambdaGrid%ncells_, nzdim ) )
-    cross_section = rZERO
+    allocate( wrkCrossSection( lambdaGrid%ncells_, nzdim ) )
+    wrkCrossSection = rZERO
 
     uLambda = this%cross_section_parms(1)%temperature(2)
 vert_loop:                                                                    &
@@ -131,11 +132,11 @@ lambda_loop:                                                                  &
         else
           sigma = rZERO
         endif
-        cross_section( lambdaNdx, vertNdx ) = sigma
+        wrkCrossSection( lambdaNdx, vertNdx ) = sigma
       enddo lambda_loop
     enddo vert_loop
 
-    cross_section = transpose( cross_section )
+    cross_section = transpose( wrkCrossSection )
 
     deallocate( zGrid )
     deallocate( lambdaGrid )

--- a/src/cross_sections/hno3-oh_no2.F90
+++ b/src/cross_sections/hno3-oh_no2.F90
@@ -176,6 +176,7 @@ contains
     real(dk), parameter         :: T0 = 298._dk
     integer           :: vertNdx
     real(dk),         allocatable :: Temp(:)
+    real(dk),         allocatable :: wrkCrossSection(:,:)
     class(grid_t),    pointer     :: lambdaGrid
     class(grid_t),    pointer     :: zGrid
     class(profile_t), pointer     :: temperature
@@ -185,16 +186,16 @@ contains
     temperature =>                                                            &
         profile_warehouse%get_profile( this%temperature_profile_ )
 
-    allocate( cross_section( lambdaGrid%ncells_, zGrid%ncells_ + 1 ) )
+    allocate( wrkCrossSection( lambdaGrid%ncells_, zGrid%ncells_ + 1 ) )
 
     Temp = temperature%edge_val_ - T0
     do vertNdx = 1, zGrid%ncells_ + 1
-      cross_section( :, vertNdx ) =                                           &
+      wrkCrossSection( :, vertNdx ) =                                         &
           this%cross_section_parms(1)%array(:,1)                              &
           * exp( this%cross_section_parms(1)%array(:,2) * Temp( vertNdx ) )
     enddo
 
-    cross_section = transpose( cross_section )
+    cross_section = transpose( wrkCrossSection )
 
     deallocate( zGrid )
     deallocate( lambdaGrid )

--- a/src/cross_sections/hobr-oh_br.F90
+++ b/src/cross_sections/hobr-oh_br.F90
@@ -84,6 +84,7 @@ contains
     integer                    :: nzdim
     integer                    :: vertNdx
     real(dk),      allocatable :: wrkCrossSection(:)
+    real(dk),      allocatable :: wrkCrossSection2D(:,:)
     class(grid_t), pointer     :: zGrid
     class(grid_t), pointer     :: lambdaGrid
 
@@ -97,7 +98,7 @@ contains
       endif
     endif
 
-    allocate( cross_section( lambdaGrid%ncells_,nzdim ) )
+    allocate( wrkCrossSection2D( lambdaGrid%ncells_,nzdim ) )
     allocate( wrkCrossSection( lambdaGrid%ncells_ ) )
 
     associate( wc => lambdaGrid%mid_ )
@@ -113,10 +114,10 @@ contains
     end associate
 
     do vertNdx = 1,nzdim
-      cross_section( :, vertNdx ) = wrkCrossSection
+      wrkCrossSection2D( :, vertNdx ) = wrkCrossSection
     enddo
 
-    cross_section = transpose( cross_section )
+    cross_section = transpose( wrkCrossSection2D )
 
     deallocate( zGrid )
     deallocate( lambdaGrid )

--- a/src/cross_sections/n2o-n2_o1d.F90
+++ b/src/cross_sections/n2o-n2_o1d.F90
@@ -99,6 +99,7 @@ contains
     integer :: lambdaNdx, nzdim, vertNdx
     real(dk)    :: lambda, Tadj, A, B
     real(dk),         allocatable :: modelTemp(:)
+    real(dk),         allocatable :: wrkCrossSection(:,:)
     class(grid_t),    pointer     :: zGrid
     class(grid_t),    pointer     :: lambdaGrid
     class(profile_t), pointer     :: mdlTemperature
@@ -120,8 +121,8 @@ contains
       modelTemp = mdlTemperature%edge_val_
     endif
 
-    allocate( cross_section( lambdaGrid%ncells_, nzdim ) )
-    cross_section = rZERO
+    allocate( wrkCrossSection( lambdaGrid%ncells_, nzdim ) )
+    wrkCrossSection = rZERO
 
     !*** quantum yield of N(4s) and NO(2Pi) is less than 1% (Greenblatt and
     !*** Ravishankara), so quantum yield of O(1D) is assumed to be unity
@@ -134,12 +135,12 @@ contains
               * lambda+A0
           B = ( ( B3 * lambda + B2 ) * lambda + B1 ) * lambda + B0
           B = ( Tadj - Thold ) * exp( B )
-          cross_section( lambdaNdx, vertNdx ) = exp( A + B )
+          wrkCrossSection( lambdaNdx, vertNdx ) = exp( A + B )
         endif
       enddo
     enddo
 
-    cross_section = transpose( cross_section )
+    cross_section = transpose( wrkCrossSection )
 
     deallocate( zGrid )
     deallocate( lambdaGrid )

--- a/src/cross_sections/n2o5-no2_no3.F90
+++ b/src/cross_sections/n2o5-no2_no3.F90
@@ -94,6 +94,7 @@ contains
     integer :: lambdaNdx, nzdim, vertNdx
     real(dk)    :: Tadj, Tfac
     real(dk),         allocatable :: modelTemp(:)
+    real(dk),         allocatable :: wrkCrossSection(:,:)
     class(grid_t),    pointer     :: zGrid
     class(grid_t),    pointer     :: lambdaGrid
     class(profile_t), pointer     :: mdlTemperature
@@ -115,20 +116,20 @@ contains
       modelTemp = mdlTemperature%edge_val_
     endif
 
-    allocate( cross_section( lambdaGrid%ncells_, nzdim ) )
-    cross_section = rZERO
+    allocate( wrkCrossSection( lambdaGrid%ncells_, nzdim ) )
+    wrkCrossSection = rZERO
 
     do vertNdx = 1, nzdim
       Tadj = max( Tfloor, min( modelTemp( vertNdx ), Tceil ) )
       do lambdaNdx = 1, lambdaGrid%ncells_
         Tfac = Tsf * this%cross_section_parms(2)%array( lambdaNdx, 1 )        &
                    * ( Tceil - Tadj ) / ( Tceil * Tadj )
-        cross_section( lambdaNdx, vertNdx ) =                                 &
+        wrkCrossSection( lambdaNdx, vertNdx ) =                               &
             this%cross_section_parms(1)%array( lambdaNdx, 1 ) * rTEN**( Tfac )
       enddo
     enddo
 
-    cross_section = transpose( cross_section )
+    cross_section = transpose( wrkCrossSection )
 
     deallocate( zGrid )
     deallocate( lambdaGrid )

--- a/src/cross_sections/nitroxy_acetone.F90
+++ b/src/cross_sections/nitroxy_acetone.F90
@@ -84,6 +84,7 @@ contains
     integer            :: nzdim
     integer            :: vertNdx
     real(dk),      allocatable :: wrkCrossSection(:)
+    real(dk),      allocatable :: wrkCrossSection2D(:,:)
     class(grid_t), pointer     :: zGrid
     class(grid_t), pointer     :: lambdaGrid
 
@@ -97,7 +98,7 @@ contains
       endif
     endif
 
-    allocate( cross_section( lambdaGrid%ncells_, nzdim ) )
+    allocate( wrkCrossSection2D( lambdaGrid%ncells_, nzdim ) )
     allocate( wrkCrossSection( lambdaGrid%ncells_ ) )
 
     where( lambdaGrid%mid_ >= 284._dk .and. lambdaGrid%mid_ <= 335._dk )
@@ -108,10 +109,10 @@ contains
     endwhere
 
     do vertNdx = 1, nzdim
-      cross_section( :, vertNdx ) = wrkCrossSection
+      wrkCrossSection2D( :, vertNdx ) = wrkCrossSection
     enddo
 
-    cross_section = transpose( cross_section )
+    cross_section = transpose( wrkCrossSection2D )
 
     deallocate( zGrid )
     deallocate( lambdaGrid )

--- a/src/cross_sections/nitroxy_ethanol.F90
+++ b/src/cross_sections/nitroxy_ethanol.F90
@@ -84,6 +84,7 @@ contains
     integer            :: nzdim
     integer            :: vertNdx
     real(dk),      allocatable :: wrkCrossSection(:)
+    real(dk),      allocatable :: wrkCrossSection2D(:,:)
     class(grid_t), pointer     :: zGrid
     class(grid_t), pointer     :: lambdaGrid
 
@@ -97,7 +98,7 @@ contains
       endif
     endif
 
-    allocate( cross_section( lambdaGrid%ncells_, nzdim ) )
+    allocate( wrkCrossSection2D( lambdaGrid%ncells_, nzdim ) )
     allocate( wrkCrossSection( lambdaGrid%ncells_ ) )
 
     where( lambdaGrid%mid_ >= 270._dk .and. lambdaGrid%mid_ <= 306._dk )
@@ -108,10 +109,10 @@ contains
     endwhere
 
     do vertNdx = 1, nzdim
-      cross_section( :, vertNdx ) = wrkCrossSection
+      wrkCrossSection2D( :, vertNdx ) = wrkCrossSection
     enddo
 
-    cross_section = transpose( cross_section )
+    cross_section = transpose( wrkCrossSection2D )
 
     deallocate( zGrid )
     deallocate( lambdaGrid )

--- a/src/cross_sections/no2_tint.F90
+++ b/src/cross_sections/no2_tint.F90
@@ -137,8 +137,10 @@ contains
       call assert_msg( 834627068, nTemps >= nParms,                           &
                        'File: '//file_path//' temperature array has less '//  &
                        'than the number of parameters.' )
-      Xsection%deltaT = Xsection%temperature( 2 : nParms )                    &
-                        - Xsection%temperature( 1 : nParms - 1 )
+      if( allocated( Xsection%deltaT ) ) deallocate( Xsection%deltaT )
+      allocate( Xsection%deltaT( nParms - 1 ) )
+      Xsection%deltaT(:) = Xsection%temperature( 2 : nParms )                 &
+                          - Xsection%temperature( 1 : nParms - 1 )
       monopos = all( Xsection%deltaT > rZERO )
       if( .not. monopos ) then
         call assert_msg( 655847084, .not. any( Xsection%deltaT > rZERO ),     &
@@ -154,8 +156,10 @@ contains
               netcdf_obj%parameters( :, Ndxu )
           netcdf_obj%parameters( :, Ndxu ) = data_parameter
         enddo
-        Xsection%deltaT = Xsection%temperature( 2 : nParms )                  &
-                          - Xsection%temperature( 1 : nParms - 1 )
+        if( allocated( Xsection%deltaT ) ) deallocate( Xsection%deltaT )
+        allocate( Xsection%deltaT( nParms - 1 ) )
+        Xsection%deltaT(:) = Xsection%temperature( 2 : nParms )               &
+                            - Xsection%temperature( 1 : nParms - 1 )
       endif
 
       ! interpolate from data to model wavelength grid

--- a/src/cross_sections/o3_tint.F90
+++ b/src/cross_sections/o3_tint.F90
@@ -152,8 +152,10 @@ contains
       Xsection%temperature = netcdf_obj%temperature
       nTemps = size( Xsection%temperature )
       if( nTemps > 1 ) then
-        Xsection%deltaT = Xsection%temperature( 2 : nParms )                  &
-                          - Xsection%temperature( 1 : nParms - 1 )
+        if( allocated( Xsection%deltaT ) ) deallocate( Xsection%deltaT )
+        allocate( Xsection%deltaT( nParms - 1 ) )
+        Xsection%deltaT(:) = Xsection%temperature( 2 : nParms )               &
+                            - Xsection%temperature( 1 : nParms - 1 )
         monopos = all( Xsection%deltaT > rZERO )
         if( .not. monopos ) then
           if( any( Xsection%deltaT > rZERO ) ) then
@@ -171,8 +173,10 @@ contains
                 netcdf_obj%parameters( :, Ndxu )
             netcdf_obj%parameters( :, Ndxu ) = data_parameter
           enddo
-          Xsection%deltaT = Xsection%temperature( 2 : nParms )                &
-                            - Xsection%temperature( 1 : nParms - 1 )
+          if( allocated( Xsection%deltaT ) ) deallocate( Xsection%deltaT )
+          allocate( Xsection%deltaT( nParms - 1 ) )
+          Xsection%deltaT(:) = Xsection%temperature( 2 : nParms )             &
+                              - Xsection%temperature( 1 : nParms - 1 )
         endif
       endif
 

--- a/src/cross_sections/oclo.F90
+++ b/src/cross_sections/oclo.F90
@@ -85,6 +85,7 @@ contains
     integer :: vertNdx, nzdim
     real(dk)    :: Tfac
     real(dk),         allocatable :: wrkCrossSection(:)
+    real(dk),         allocatable :: wrkCrossSection2D(:,:)
     real(dk),         allocatable :: modelTemp(:)
     class(grid_t),    pointer     :: zGrid
     class(grid_t),    pointer     :: lambdaGrid
@@ -107,9 +108,9 @@ contains
       modelTemp = mdlTemperature%edge_val_
     endif
 
-    allocate( cross_section( lambdaGrid%ncells_, nzdim ) )
+    allocate( wrkCrossSection2D( lambdaGrid%ncells_, nzdim ) )
     allocate( wrkCrossSection( lambdaGrid%ncells_ ) )
-    cross_section = rZERO
+    wrkCrossSection2D = rZERO
 
     associate( Temp => modelTemp, Xsection => this%cross_section_parms )
     nParms = size( Xsection )
@@ -132,11 +133,11 @@ contains
                         + Tfac * ( Xsection( ndx + 1 )%array(:,1)             &
                                    - Xsection( ndx )%array(:,1) )
       endif
-      cross_section( :, vertNdx ) = wrkCrossSection
+      wrkCrossSection2D( :, vertNdx ) = wrkCrossSection
     enddo
     end associate
 
-    cross_section = transpose( cross_section )
+    cross_section = transpose( wrkCrossSection2D )
 
     deallocate( zGrid )
     deallocate( lambdaGrid )

--- a/src/cross_sections/rono2.F90
+++ b/src/cross_sections/rono2.F90
@@ -191,6 +191,7 @@ contains
     real(dk), parameter :: T0 = 298._dk
     real(dk) :: Temp
     real(dk),         allocatable :: modelTemp(:)
+    real(dk),         allocatable :: wrkCrossSection(:,:)
     class(grid_t),    pointer     :: zGrid
     class(grid_t),    pointer     :: lambdaGrid
     class(profile_t), pointer     :: mdlTemperature
@@ -212,16 +213,17 @@ contains
       modelTemp = mdlTemperature%edge_val_
     endif
 
-    allocate( cross_section( lambdaGrid%ncells_, nzdim ) )
-    cross_section = rZERO
+    allocate( wrkCrossSection( lambdaGrid%ncells_, nzdim ) )
+    wrkCrossSection = rZERO
 
     do vertNdx = 1, nzdim
       Temp = modelTemp( vertNdx ) - T0
-      cross_section( :, vertNdx ) = this%cross_section_parms(1)%array(:,1)    &
+      wrkCrossSection( :, vertNdx ) =                                         &
+                          this%cross_section_parms(1)%array(:,1)              &
                         * exp( this%cross_section_parms(1)%array(:,2) * Temp )
     enddo
 
-    cross_section = transpose( cross_section )
+    cross_section = transpose( wrkCrossSection )
 
     deallocate( zGrid )
     deallocate( lambdaGrid )

--- a/src/cross_sections/t_butyl_nitrate.F90
+++ b/src/cross_sections/t_butyl_nitrate.F90
@@ -81,6 +81,7 @@ contains
     real(dk), parameter :: b = 0.5307_dk
     real(dk), parameter :: c = -115.5_dk
     integer(ik)            :: nzdim, vertNdx
+    real(dk),      allocatable :: wrkCrossSection(:,:)
     class(grid_t), pointer :: zGrid
     class(grid_t), pointer :: lambdaGrid
 
@@ -94,20 +95,20 @@ contains
       endif
     endif
 
-    allocate( cross_section( lambdaGrid%ncells_, nzdim ) )
-    cross_section = rZERO
+    allocate( wrkCrossSection( lambdaGrid%ncells_, nzdim ) )
+    wrkCrossSection = rZERO
 
     where( lambdaGrid%mid_ >= 270._dk .and. lambdaGrid%mid_ <= 330._dk )
-      cross_section(:,1) =                                                    &
+      wrkCrossSection(:,1) =                                                  &
           exp( c + lambdaGrid%mid_ * ( b +  a * lambdaGrid%mid_ ) )
     elsewhere
-      cross_section(:,1) = rZERO
+      wrkCrossSection(:,1) = rZERO
     endwhere
     do vertNdx = 2, nzdim
-      cross_section( :, vertNdx ) = cross_section(:,1)
+      wrkCrossSection( :, vertNdx ) = wrkCrossSection(:,1)
     enddo
 
-    cross_section = transpose( cross_section )
+    cross_section = transpose( wrkCrossSection )
 
     deallocate( zGrid )
     deallocate( lambdaGrid )

--- a/src/cross_sections/tint.F90
+++ b/src/cross_sections/tint.F90
@@ -136,8 +136,10 @@ contains
       call assert_msg( 114433594, nTemps >= nParms,                           &
                        'File: '//file_path//' temperature array has fewer '// &
                        'entries than there are parameters.' )
-      Xsection%deltaT = Xsection%temperature( 2 : nParms )                    &
-                        - Xsection%temperature( 1 : nParms - 1 )
+      if( allocated( Xsection%deltaT ) ) deallocate( Xsection%deltaT )
+      allocate( Xsection%deltaT( nParms - 1 ) )
+      Xsection%deltaT(:) = Xsection%temperature( 2 : nParms )                 &
+                          - Xsection%temperature( 1 : nParms - 1 )
       monopos = all( Xsection%deltaT > rZERO )
       if( .not. monopos ) then
         call assert_msg( 277872952, .not. any( Xsection%deltaT > rZERO ),     &
@@ -153,8 +155,10 @@ contains
               netcdf_obj%parameters( :, Ndxu )
           netcdf_obj%parameters( :, Ndxu ) = data_parameter
         enddo
-        Xsection%deltaT = Xsection%temperature( 2 : nParms )              &
-                          - Xsection%temperature( 1 : nParms - 1 )
+        if( allocated( Xsection%deltaT ) ) deallocate( Xsection%deltaT )
+        allocate( Xsection%deltaT( nParms - 1 ) )
+        Xsection%deltaT(:) = Xsection%temperature( 2 : nParms )           &
+                            - Xsection%temperature( 1 : nParms - 1 )
       endif
 
       ! interpolate from data to model wavelength grid

--- a/src/grid_warehouse.F90
+++ b/src/grid_warehouse.F90
@@ -42,7 +42,7 @@ module tuvx_grid_warehouse
     !> Unpacks a warehouse from a character buffer into the object
     procedure :: mpi_unpack
     !> Finalize the object
-    final :: finalize
+    final :: finalize_grid_warehouse
   end type grid_warehouse_t
 
   !> Grid warehouse_t constructor
@@ -481,7 +481,7 @@ contains
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-  subroutine finalize( this )
+  subroutine finalize_grid_warehouse( this )
     ! Finalize grid warehouse
 
     !> Arguments
@@ -498,7 +498,7 @@ contains
       deallocate( this%grids_ )
     endif
 
-  end subroutine finalize
+  end subroutine finalize_grid_warehouse
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/src/grids/from_config.F90
+++ b/src/grids/from_config.F90
@@ -55,9 +55,11 @@ contains
     call config%get( "values", this%edge_, Iam )
 
     this%ncells_ = size( this%edge_ ) - 1
-    this%mid_ = .5_dk *                                                       &
+    allocate( this%mid_( this%ncells_ ) )
+    allocate( this%delta_( this%ncells_ ) )
+    this%mid_(:) = .5_dk *                                                    &
       ( this%edge_( 1 : this%ncells_ ) + this%edge_( 2 : this%ncells_ + 1 ) )
-    this%delta_ =                                                             &
+    this%delta_(:) =                                                          &
       this%edge_( 2 : this%ncells_ + 1 ) - this%edge_( 1 : this%ncells_ )
 
   end function constructor

--- a/src/heating_rates.F90
+++ b/src/heating_rates.F90
@@ -184,7 +184,10 @@ contains
     class(grid_t), pointer :: wavelengths
     real(kind=dk) :: energy_term
     type(string_t) :: required_keys(4), optional_keys(1)
-    type(string_t) :: heating_required_keys(1), heating_optional_keys(0)
+    type(string_t) :: heating_required_keys(1)
+    type(string_t), allocatable :: heating_optional_keys(:)
+
+    allocate(heating_optional_keys(0))
 
     required_keys(1) = "name"
     required_keys(2) = "cross section"
@@ -312,15 +315,19 @@ contains
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
   !> Returns the names of each photolysis reaction with a heating rate
-  function labels( this )
+  function labels( this ) result(res)
 
-    !> Photolysis reaction labels
-    type(string_t), allocatable :: labels(:)
     !> Heating rate collection
     class(heating_rates_t), intent(in) :: this
+    !> Photolysis reaction labels
+    type(string_t), allocatable :: res(:)
+    integer :: i
 
-    allocate( labels( size( this%heating_parameters_ ) ) )
-    labels(:) = this%heating_parameters_(:)%label_
+    allocate( res( size( this%heating_parameters_ ) ) )
+
+    do i = 1, size(res)
+      res(i) = this%heating_parameters_(i)%label_
+    end do
 
   end function labels
 

--- a/src/la_sr_bands.F90
+++ b/src/la_sr_bands.F90
@@ -707,14 +707,16 @@ contains
     NORM = rONE/ real( nz - iONE, dk )
     do k = iONE, nz
       o2col1( k ) = max( o2col( k ), colmin )
-      x  = log( o2col1( k ) )
-      if( x < 38.0_dk ) then
+      if( o2col( k ) < colmin ) then
         ktop1 = k - iONE
         ktop  = min( ktop1, ktop )
-      else if( x > 56.0_dk ) then
-        kbot = k
       else
-        o2_cross_section_k( k, : nsrb ) = this%effxs( x, tlev( k ) )
+        x  = log( o2col1( k ) )
+        if( x > 56.0_dk ) then
+          kbot = k
+        else
+          o2_cross_section_k( k, : nsrb ) = this%effxs( x, tlev( k ) )
+        endif
       endif
     enddo
 
@@ -805,14 +807,16 @@ contains
     kbot = 0
     do k = iONE, nz
       o2col1( k ) = max( o2col( k ), colmin )
-      x = log( o2col1( k ) )
-      if( x < 38.0_dk ) then
+      if( o2col( k ) < colmin ) then
         ktop1 = k - 1
         ktop  = min( ktop1, ktop )
-      else if ( x > 56.0_dk ) then
-        kbot = k
       else
-        o2_cross_section_k( k, : nsrb ) = this%effxs( x, tlev( k ) )
+        x = log( o2col1( k ) )
+        if ( x > 56.0_dk ) then
+          kbot = k
+        else
+          o2_cross_section_k( k, : nsrb ) = this%effxs( x, tlev( k ) )
+        endif
       endif
     enddo
 

--- a/src/la_sr_bands.F90
+++ b/src/la_sr_bands.F90
@@ -904,7 +904,8 @@ contains
 
     call this%calc_params( X, A, B )
 
-    XS = exp( A * ( T - T0 ) + B )
+    allocate( XS( nsrb ) )
+    XS(:) = exp( A * ( T - T0 ) + B )
 
   end function effxs
 

--- a/src/la_sr_bands.F90
+++ b/src/la_sr_bands.F90
@@ -925,8 +925,8 @@ contains
     ! call Chebyshev Evaluation routine to calc A and B from
     !	set of 20 coeficients for each wavelength
     do I = 1,size( A )
-      A(I) = this%chebyshev_evaluation( this%AC( 1, I ), X )
-      B(I) = this%chebyshev_evaluation( this%BC( 1, I ), X )
+      A(I) = this%chebyshev_evaluation( this%AC( :, I ), X )
+      B(I) = this%chebyshev_evaluation( this%BC( :, I ), X )
     enddo
 
   end subroutine calc_params

--- a/src/la_sr_bands.F90
+++ b/src/la_sr_bands.F90
@@ -896,7 +896,7 @@ contains
     class(la_sr_bands_t), intent(inout)  :: this
     real(dk), intent(in)  :: T
     real(dk), intent(in)  :: X
-    real(dk), allocatable :: XS(:)
+    real(dk)              :: XS( nsrb )
 
     ! Local variables
     real(dk), parameter :: T0 = 220._dk
@@ -904,7 +904,6 @@ contains
 
     call this%calc_params( X, A, B )
 
-    allocate( XS( nsrb ) )
     XS(:) = exp( A * ( T - T0 ) + B )
 
   end function effxs

--- a/src/netcdf.F90
+++ b/src/netcdf.F90
@@ -18,7 +18,7 @@ module tuvx_netcdf
     real(musica_dk), allocatable :: parameters(:,:)
   contains
     procedure :: read_netcdf_file => run
-    final     :: finalize
+    final     :: finalize_netcdf
   end type netcdf_t
 
 contains
@@ -79,7 +79,7 @@ contains
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-  subroutine finalize( this )
+  subroutine finalize_netcdf( this )
     ! Cleans up memory of the NetCDF class
 
     type(netcdf_t), intent(inout) :: this
@@ -94,7 +94,7 @@ contains
       deallocate( this%parameters )
     endif
 
-  end subroutine finalize
+  end subroutine finalize_netcdf
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/src/output.F90
+++ b/src/output.F90
@@ -34,7 +34,7 @@ module tuvx_output
     procedure :: output
     procedure, private :: add_grids
     procedure, private :: add_photolysis_diagnostics
-    final :: finalize
+    final :: finalize_output_t
   end type output_t
 
   interface output_t
@@ -337,13 +337,13 @@ contains
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
   !> Cleans up memory
-  subroutine finalize( this )
+  subroutine finalize_output_t( this )
 
     type(output_t), intent(inout) :: this
 
     if( associated( this%file_ ) ) deallocate( this%file_ )
 
-  end subroutine finalize
+  end subroutine finalize_output_t
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/src/photolysis_rates.F90
+++ b/src/photolysis_rates.F90
@@ -370,6 +370,9 @@ rate_loop:                                                                    &
       end associate
       end if
 
+      if (.not. allocated( xsqy ) ) then
+        allocate( xsqy( size( cross_section, 2 ), size( cross_section, 1 ) ) )
+      end if
       xsqy = transpose( cross_section * quantum_yield )
       do vertNdx = 1, zGrid%ncells_ + 1
         photolysis_rates( vertNdx, rateNdx ) =                                &

--- a/src/profile_warehouse.F90
+++ b/src/profile_warehouse.F90
@@ -43,7 +43,7 @@ module tuvx_profile_warehouse
     procedure :: mpi_pack
     ! unpacks a warehouse from a character buffer into the object
     procedure :: mpi_unpack
-    final :: finalize
+    final :: finalize_profile_warehouse
   end type profile_warehouse_t
 
   interface profile_warehouse_t
@@ -488,7 +488,7 @@ contains
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-  subroutine finalize( this )
+  subroutine finalize_profile_warehouse( this )
     ! Finalize profile warehouse
 
     use musica_constants, only : ik => musica_ik
@@ -508,7 +508,7 @@ contains
       deallocate( this%profiles_ )
     endif
 
-  end subroutine finalize
+  end subroutine finalize_profile_warehouse
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/src/profiles/air.F90
+++ b/src/profiles/air.F90
@@ -144,13 +144,16 @@ contains
                                      this%handle_%val_//" profile height grid" )
     this%edge_val_ = exp( this%edge_val_ )
 
-    this%mid_val_ = .5_dk * ( this%edge_val_( 1 : this%ncells_ ) +            &
+    allocate( this%mid_val_( this%ncells_ ) )
+    allocate( this%delta_val_( this%ncells_ ) )
+    allocate( this%layer_dens_( this%ncells_ ) )
+    this%mid_val_(:) = .5_dk * ( this%edge_val_( 1 : this%ncells_ ) +         &
       this%edge_val_( 2 : this%ncells_ + 1 ) )
 
-    this%delta_val_ = ( this%edge_val_( 2 : this%ncells_ + 1 ) -              &
+    this%delta_val_(:) = ( this%edge_val_( 2 : this%ncells_ + 1 ) -           &
       this%edge_val_( 1 : this%ncells_ ) )
 
-    this%layer_dens_ = zGrid%delta_ *                                         &
+    this%layer_dens_(:) = zGrid%delta_ *                                      &
       sqrt( this%edge_val_( 1 : this%ncells_ ) ) *                            &
       sqrt( this%edge_val_( 2 : this%ncells_ + 1 ) ) * km2cm
 

--- a/src/profiles/air.F90
+++ b/src/profiles/air.F90
@@ -13,7 +13,7 @@ module tuvx_profile_air
 
   type, extends(profile_t) :: profile_air_t
   contains
-    final     :: finalize
+    final     :: finalize_profile_air
   end type profile_air_t
 
   interface profile_air_t
@@ -176,7 +176,7 @@ contains
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-  subroutine finalize( this )
+  subroutine finalize_profile_air( this )
     ! Clean up this object
 
     type(profile_air_t), intent(inout) :: this
@@ -200,7 +200,7 @@ contains
       deallocate( this%burden_dens_ )
     endif
 
-  end subroutine finalize
+  end subroutine finalize_profile_air
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/src/profiles/earth_sun_distance.F90
+++ b/src/profiles/earth_sun_distance.F90
@@ -91,10 +91,12 @@ contains
       this%edge_val_  = [ this%edge_val_, soldst ]
     enddo
 
-    this%mid_val_ = .5_dk * ( this%edge_val_( 1 : this%ncells_ ) +            &
+    allocate( this%mid_val_( this%ncells_ ) )
+    allocate( this%delta_val_( this%ncells_ ) )
+    this%mid_val_(:) = .5_dk * ( this%edge_val_( 1 : this%ncells_ ) +         &
       this%edge_val_( 2 : this%ncells_ + 1 ) )
 
-    this%delta_val_ = ( this%edge_val_( 2 : this%ncells_ + 1 ) -              &
+    this%delta_val_(:) = ( this%edge_val_( 2 : this%ncells_ + 1 ) -           &
       this%edge_val_( 1 : this%ncells_ ) )
 
     deallocate( timeGrid )

--- a/src/profiles/earth_sun_distance.F90
+++ b/src/profiles/earth_sun_distance.F90
@@ -18,7 +18,7 @@ module tuvx_profile_earth_sun_distance
 
   type, extends(profile_t) :: profile_earth_sun_distance_t
   contains
-    final     :: finalize
+    final     :: finalize_profile_earth_sun_distance
   end type profile_earth_sun_distance_t
 
   !> Constructor
@@ -104,7 +104,7 @@ contains
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-  subroutine finalize( this )
+  subroutine finalize_profile_earth_sun_distance( this )
     ! Cleanup the memory used by this object
 
     type(profile_earth_sun_distance_t), intent(inout) :: this ! This f:type:`~tuvx_profile_earth_sun_distance/profile_earth_sun_distance_t`
@@ -119,7 +119,7 @@ contains
       deallocate( this%delta_val_ )
     endif
 
-  end subroutine finalize
+  end subroutine finalize_profile_earth_sun_distance
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/src/profiles/extraterrestrial_flux.F90
+++ b/src/profiles/extraterrestrial_flux.F90
@@ -13,7 +13,7 @@ module tuvx_profile_extraterrestrial_flux
 
   type, extends(profile_t) :: profile_extraterrestrial_flux_t
   contains
-    final     :: finalize
+    final     :: finalize_profile_extraterrestrial_flux
   end type profile_extraterrestrial_flux_t
 
   !> Constructor
@@ -274,7 +274,7 @@ contains
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-  subroutine finalize( this )
+  subroutine finalize_profile_extraterrestrial_flux( this )
     ! Cleanup the memory used by this object
 
     type(profile_extraterrestrial_flux_t), intent(inout) :: this ! This f:type:`~tuvx_profile_extraterrestrial_flux/profile_extraterrestrial_flux_t`
@@ -284,7 +284,7 @@ contains
     if( allocated( this%delta_val_ ) ) deallocate( this%delta_val_ )
     if( allocated( this%layer_dens_ ) ) deallocate( this%layer_dens_ )
 
-  end subroutine finalize
+  end subroutine finalize_profile_extraterrestrial_flux
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/src/profiles/from_config.F90
+++ b/src/profiles/from_config.F90
@@ -119,13 +119,16 @@ contains
       return
     end if
 
-    this%mid_val_ = .5_dk * ( this%edge_val_( 1 : this%ncells_ ) +            &
+    allocate( this%mid_val_( this%ncells_ ) )
+    allocate( this%delta_val_( this%ncells_ ) )
+    allocate( this%layer_dens_( this%ncells_ ) )
+    this%mid_val_(:) = .5_dk * ( this%edge_val_( 1 : this%ncells_ ) +         &
                               this%edge_val_( 2 : this%ncells_ + 1 ) )
 
-    this%delta_val_ = ( this%edge_val_( 2 : this%ncells_ + 1 ) -              &
+    this%delta_val_(:) = ( this%edge_val_( 2 : this%ncells_ + 1 ) -           &
                         this%edge_val_( 1 : this%ncells_ ) )
 
-    this%layer_dens_ = this%mid_val_ * grid%delta_ * unit_conv
+    this%layer_dens_(:) = this%mid_val_ * grid%delta_ * unit_conv
 
     this%exo_layer_dens_ = [ this%layer_dens_, exo_layer_dens ]
 

--- a/src/profiles/from_csv_file.F90
+++ b/src/profiles/from_csv_file.F90
@@ -14,7 +14,7 @@ module tuvx_profile_from_csv_file
 
   type, extends(profile_t) :: profile_from_csv_file_t
   contains
-    final     :: finalize
+    final     :: finalize_profile_from_csv_file
   end type profile_from_csv_file_t
 
   interface profile_from_csv_file_t
@@ -188,7 +188,7 @@ contains
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-  subroutine finalize( this )
+  subroutine finalize_profile_from_csv_file( this )
     ! Cleanup the memory used by this object
 
     type(profile_from_csv_file_t), intent(inout) :: this ! This f:type:`~tuvx_profile_from_csv_file/profile_from_csv_file_t`
@@ -207,7 +207,7 @@ contains
       deallocate( this%layer_dens_ )
     endif
 
-  end subroutine finalize
+  end subroutine finalize_profile_from_csv_file
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/src/profiles/from_csv_file.F90
+++ b/src/profiles/from_csv_file.F90
@@ -148,10 +148,12 @@ contains
     this%edge_val_ = theInterpolator%interpolate( grid%edge_, zdata, profile, &
                                      this%handle_%val_//" profile height grid" )
 
-    this%mid_val_ = .5_dk * ( this%edge_val_( 1 : this%ncells_ ) +            &
+    allocate( this%mid_val_( this%ncells_ ) )
+    allocate( this%delta_val_( this%ncells_ ) )
+    this%mid_val_(:) = .5_dk * ( this%edge_val_( 1 : this%ncells_ ) +         &
                               this%edge_val_( 2 : this%ncells_ + 1 ) )
 
-    this%delta_val_  = ( this%edge_val_( 2 : this%ncells_ + 1 ) -             &
+    this%delta_val_(:) = ( this%edge_val_( 2 : this%ncells_ + 1 ) -           &
                          this%edge_val_( 1 : this%ncells_) )
 
     ! This can be removed as part of issue #139 for adopting SI units
@@ -161,7 +163,8 @@ contains
       unit_conv = 1.0_dk
     end if
 
-    this%layer_dens_ = this%mid_val_ * grid%delta_ * unit_conv
+    allocate( this%layer_dens_( this%ncells_ ) )
+    this%layer_dens_(:) = this%mid_val_ * grid%delta_ * unit_conv
 
     this%layer_dens_( this%ncells_ ) = this%layer_dens_( this%ncells_ )
 

--- a/src/profiles/o2.F90
+++ b/src/profiles/o2.F90
@@ -147,13 +147,16 @@ contains
     this%edge_val_ = exp( this%edge_val_ )
     this%edge_val_ = o2Vmr * this%edge_val_
 
-    this%mid_val_ = .5_dk * ( this%edge_val_( 1 : this%ncells_ ) +            &
+    allocate( this%mid_val_( this%ncells_ ) )
+    allocate( this%delta_val_( this%ncells_ ) )
+    allocate( this%layer_dens_( this%ncells_ ) )
+    this%mid_val_(:) = .5_dk * ( this%edge_val_( 1 : this%ncells_ ) +         &
                               this%edge_val_( 2 : this%ncells_ + 1 ) )
 
-    this%delta_val_ = ( this%edge_val_( 2 : this%ncells_ + 1 ) -              &
+    this%delta_val_(:) = ( this%edge_val_( 2 : this%ncells_ + 1 ) -           &
                         this%edge_val_( 1 : this%ncells_ ) )
 
-    this%layer_dens_ = zGrid%delta_ *                                         &
+    this%layer_dens_(:) = zGrid%delta_ *                                      &
       sqrt( this%edge_val_( 1 : this%ncells_ ) ) *                            &
       sqrt( this%edge_val_( 2 : this%ncells_ + 1 ) ) * km2cm
 

--- a/src/profiles/o2.F90
+++ b/src/profiles/o2.F90
@@ -13,7 +13,7 @@ module tuvx_profile_o2
 
   type, extends(profile_t) :: profile_o2_t
   contains
-    final     :: finalize
+    final     :: finalize_profile_o2
   end type profile_o2_t
 
   interface profile_o2_t
@@ -171,7 +171,7 @@ contains
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-  subroutine finalize( this )
+  subroutine finalize_profile_o2( this )
     ! Cleanup the memory used by this object
 
     type(profile_o2_t), intent(inout) :: this ! This f:type:`~tuvx_profile_o2/profile_o2_t`
@@ -192,7 +192,7 @@ contains
       deallocate( this%exo_layer_dens_ )
     endif
 
-  end subroutine finalize
+  end subroutine finalize_profile_o2
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/src/profiles/o3.F90
+++ b/src/profiles/o3.F90
@@ -161,13 +161,16 @@ contains
     this%edge_val_ = theInterpolator%interpolate( zGrid%edge_, zdata, profile,&
                                      this%handle_%val_//" profile height grid" )
 
-    this%mid_val_ = .5_dk * ( this%edge_val_( 1 : this%ncells_ ) +            &
+    allocate( this%mid_val_( this%ncells_ ) )
+    allocate( this%delta_val_( this%ncells_ ) )
+    allocate( this%layer_dens_( this%ncells_ ) )
+    this%mid_val_(:) = .5_dk * ( this%edge_val_( 1 : this%ncells_ ) +         &
                               this%edge_val_( 2 : this%ncells_ + 1 ) )
 
-    this%delta_val_ = this%edge_val_( 2 : this%ncells_ + 1 ) -                &
+    this%delta_val_(:) = this%edge_val_( 2 : this%ncells_ + 1 ) -             &
                       this%edge_val_( 1 : this%ncells_ )
 
-    this%layer_dens_ = zGrid%delta_ * this%mid_val_ * km2cm
+    this%layer_dens_(:) = zGrid%delta_ * this%mid_val_ * km2cm
 
     this%layer_dens_( this%ncells_ ) = this%layer_dens_( this%ncells_ ) +     &
         this%edge_val_( this%ncells_ + 1 ) * this%hscale_ * km2cm
@@ -179,13 +182,13 @@ contains
       if( O3ScaleFactor /= 1.0_dk ) then
         this%edge_val_ = O3ScaleFactor * this%edge_val_
 
-        this%mid_val_ = .5_dk * ( this%edge_val_( 1 : this%ncells_ ) +        &
+        this%mid_val_(:) = .5_dk * ( this%edge_val_( 1 : this%ncells_ ) +     &
                                   this%edge_val_( 2 : this%ncells_ + 1 ) )
 
-        this%delta_val_ = this%edge_val_( 2 : this%ncells_ + 1 ) -            &
+        this%delta_val_(:) = this%edge_val_( 2 : this%ncells_ + 1 ) -         &
                           this%edge_val_( 1 : this%ncells_ )
 
-        this%layer_dens_ = zGrid%delta_ * this%mid_val_ * km2cm
+        this%layer_dens_(:) = zGrid%delta_ * this%mid_val_ * km2cm
 
         this%layer_dens_( this%ncells_ ) = this%layer_dens_( this%ncells_ ) + &
             this%edge_val_( this%ncells_ + 1 ) * this%hscale_ * km2cm

--- a/src/profiles/o3.F90
+++ b/src/profiles/o3.F90
@@ -13,7 +13,7 @@ module tuvx_profile_o3
 
   type, extends(profile_t) :: profile_o3_t
   contains
-    final     :: finalize
+    final     :: finalize_o3
   end type profile_o3_t
 
   !> Constructor
@@ -200,7 +200,7 @@ contains
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-  subroutine finalize( this )
+  subroutine finalize_o3( this )
     ! Cleanup the memory used by this object
 
     type(profile_o3_t), intent(inout) :: this ! This f:type:`~tuvx_profile_o3/profile_o3_t`
@@ -218,7 +218,7 @@ contains
       deallocate( this%layer_dens_ )
     endif
 
-  end subroutine finalize
+  end subroutine finalize_o3
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/src/profiles/solar_zenith_angle.F90
+++ b/src/profiles/solar_zenith_angle.F90
@@ -18,7 +18,7 @@ module tuvx_profile_solar_zenith_angle
 
   type, extends(profile_t) :: profile_solar_zenith_angle_t
   contains
-    final     :: finalize
+    final     :: finalize_profile_solar_zenith_angle
   end type profile_solar_zenith_angle_t
 
   interface profile_solar_zenith_angle_t
@@ -107,7 +107,7 @@ contains
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-  subroutine finalize( this )
+  subroutine finalize_profile_solar_zenith_angle( this )
     ! Cleanup the memory used by this object
 
     type(profile_solar_zenith_angle_t), intent(inout) :: this ! This f:type:`~tuvx_profile_solar_zenith_angle/profile_solar_zenith_angle_t`
@@ -122,7 +122,7 @@ contains
       deallocate( this%delta_val_ )
     endif
 
-  end subroutine finalize
+  end subroutine finalize_profile_solar_zenith_angle
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/src/profiles/solar_zenith_angle.F90
+++ b/src/profiles/solar_zenith_angle.F90
@@ -93,12 +93,14 @@ contains
       this%edge_val_ = [this%edge_val_,NINETY - solarElevation]
     enddo
 
-    this%mid_val_ = .5_dk * ( &
+    allocate( this%mid_val_( this%ncells_ ) )
+    allocate( this%delta_val_( this%ncells_ ) )
+    this%mid_val_(:) = .5_dk * ( &
       this%edge_val_(1_ik:this%ncells_) + &
       this%edge_val_(2_ik:this%ncells_+1_ik) &
     )
 
-    this%delta_val_ = this%edge_val_(2_ik:this%ncells_+1_ik) - &
+    this%delta_val_(:) = this%edge_val_(2_ik:this%ncells_+1_ik) - &
       this%edge_val_(1_ik:this%ncells_)
 
     deallocate( timeGrid )

--- a/src/quantum_yields/acetone-ch3co_ch3.F90
+++ b/src/quantum_yields/acetone-ch3co_ch3.F90
@@ -129,6 +129,7 @@ contains
 
     integer                       :: lambdaNdx
     integer                       :: nzdim, vertNdx
+    real(dk),         allocatable :: wrkQuantumYield(:,:)
     real(dk),         allocatable :: modelTemp(:), modelDens(:)
     class(grid_t),    pointer     :: zGrid
     class(grid_t),    pointer     :: lambdaGrid
@@ -156,8 +157,8 @@ contains
     modelTemp = mdlTemperature%edge_val_
     modelDens = mdlDensity%edge_val_
 
-    allocate( quantum_yield( lambdaGrid%ncells_, nzdim ) )
-    quantum_yield = rZERO
+    allocate( wrkQuantumYield( lambdaGrid%ncells_, nzdim ) )
+    wrkQuantumYield = rZERO
 
 vert_loop: &
     do vertNdx = 1, nzdim
@@ -213,11 +214,11 @@ lambda_loop: &
           if( this%do_CO_ ) qy = qy + fco
           if( this%do_CH3CO_ ) qy = qy + fac
         endif
-        quantum_yield( lambdaNdx, vertNdx ) = qy
+        wrkQuantumYield( lambdaNdx, vertNdx ) = qy
       enddo lambda_loop
     enddo vert_loop
 
-    quantum_yield = transpose( quantum_yield )
+    quantum_yield = transpose( wrkQuantumYield )
 
     deallocate( zGrid )
     deallocate( lambdaGrid )

--- a/src/quantum_yields/c2h5cho.F90
+++ b/src/quantum_yields/c2h5cho.F90
@@ -74,6 +74,7 @@ contains
     integer                       :: nzdim, vertNdx
     real(dk)                      :: air_dens_fac
     real(dk),         allocatable :: quantum_yield_wrk(:)
+    real(dk),         allocatable :: wrkQuantumYield(:,:)
     real(dk),         allocatable :: modelDens(:)
     class(grid_t),    pointer     :: zGrid
     class(grid_t),    pointer     :: lambdaGrid
@@ -86,9 +87,9 @@ contains
     nzdim = zGrid%ncells_ + 1
     modelDens = mdlDensity%edge_val_
 
-    allocate( quantum_yield( lambdaGrid%ncells_, nzdim ) )
+    allocate( wrkQuantumYield( lambdaGrid%ncells_, nzdim ) )
     allocate( quantum_yield_wrk( lambdaGrid%ncells_ ) )
-    quantum_yield = rZERO
+    wrkQuantumYield = rZERO
 
     do vertNdx = 1, nzdim
       air_dens_fac = modelDens( vertNdx ) / 2.45e19_dk
@@ -102,10 +103,10 @@ contains
             * air_dens_fac )
         quantum_yield_wrk = min( rONE, quantum_yield_wrk )
       endwhere
-      quantum_yield( :, vertNdx ) = quantum_yield_wrk
+      wrkQuantumYield( :, vertNdx ) = quantum_yield_wrk
     enddo
 
-    quantum_yield = transpose( quantum_yield )
+    quantum_yield = transpose( wrkQuantumYield )
 
     deallocate( zGrid )
     deallocate( lambdaGrid )

--- a/src/quantum_yields/ch2chcho.F90
+++ b/src/quantum_yields/ch2chcho.F90
@@ -74,6 +74,7 @@ contains
 
     integer                       :: nzdim, vertNdx
     real(dk),         allocatable :: phi0(:)
+    real(dk),         allocatable :: wrkQuantumYield(:,:)
     real(dk),         allocatable :: modelDens(:)
     class(grid_t),    pointer     :: zGrid
     class(grid_t),    pointer     :: lambdaGrid
@@ -86,26 +87,26 @@ contains
     nzdim = zGrid%ncells_ + iONE
     modelDens = mdlDensity%edge_val_
 
-    allocate( quantum_yield(lambdaGrid%ncells_,nzdim) )
+    allocate( wrkQuantumYield(lambdaGrid%ncells_,nzdim) )
     allocate( phi0(lambdaGrid%ncells_) )
-    quantum_yield = rZERO
+    wrkQuantumYield = rZERO
 
     do vertNdx = iONE,nzdim
       associate( M => modelDens(vertNdx) )
       if( M > 2.6e19_dk ) then
-        quantum_yield(:,vertNdx) = phiL
+        wrkQuantumYield(:,vertNdx) = phiL
       else
         if( M <= 8.e17_dk ) then
           phi0 = phiU + 1.613e-17_dk*8.e17_dk
         else
           phi0 = phiU + 1.613e-17_dk*M
         endif
-        quantum_yield(:,vertNdx) = phiL + rONE/phi0
+        wrkQuantumYield(:,vertNdx) = phiL + rONE/phi0
       endif
       end associate
     enddo
 
-    quantum_yield = transpose( quantum_yield )
+    quantum_yield = transpose( wrkQuantumYield )
 
     deallocate( zGrid )
     deallocate( lambdaGrid )

--- a/src/quantum_yields/ch2o.F90
+++ b/src/quantum_yields/ch2o.F90
@@ -77,6 +77,7 @@ contains
     real(dk)                      :: Tfactor
     real(dk),         allocatable :: quantum_yield_tmp(:)
     real(dk),         allocatable :: quantum_yield_wrk(:)
+    real(dk),         allocatable :: wrkQuantumYield(:,:)
     real(dk),         allocatable :: modelTemp(:), modelDens(:)
     class(grid_t),    pointer     :: zGrid
     class(grid_t),    pointer     :: lambdaGrid
@@ -93,8 +94,8 @@ contains
     modelTemp = mdlTemperature%edge_val_
     modelDens = mdlDensity%edge_val_
 
-    allocate( quantum_yield( lambdaGrid%ncells_, nzdim ) )
-    quantum_yield = rZERO
+    allocate( wrkQuantumYield( lambdaGrid%ncells_, nzdim ) )
+    wrkQuantumYield = rZERO
 
     associate( quantum_yield_chnl1 => this%quantum_yield_parms(1)%array(:,1), &
                quantum_yield_chnl2 => this%quantum_yield_parms(1)%array(:,2) )
@@ -109,15 +110,15 @@ contains
                       / ( 2.45e19_dk * quantum_yield_chnl2 * quantum_yield_tmp )
         quantum_yield_wrk = quantum_yield_wrk * ( rONE                         &
                           + .05_dk * ( lambdaGrid%mid_ - 329._dk ) * Tfactor )
-        quantum_yield(:,vertNdx) = rONE / ( rONE / quantum_yield_tmp +         &
+        wrkQuantumYield(:,vertNdx) = rONE / ( rONE / quantum_yield_tmp +       &
                                    quantum_yield_wrk * modelDens( vertNdx ) )
       elsewhere
-        quantum_yield( :, vertNdx ) = quantum_yield_chnl2
+        wrkQuantumYield( :, vertNdx ) = quantum_yield_chnl2
       endwhere
     enddo
     end associate
 
-    quantum_yield = transpose( quantum_yield )
+    quantum_yield = transpose( wrkQuantumYield )
 
     deallocate( zGrid )
     deallocate( lambdaGrid )

--- a/src/quantum_yields/ch3cho-ch3_hco.F90
+++ b/src/quantum_yields/ch3cho-ch3_hco.F90
@@ -74,6 +74,7 @@ contains
     real(dk),         allocatable :: quantum_yield_chnl1(:)
     real(dk),         allocatable :: quantum_yield_chnl2(:)
     real(dk),         allocatable :: quantum_yield_wrk(:)
+    real(dk),         allocatable :: wrkQuantumYield(:,:)
     real(dk),         allocatable :: modelDens(:)
     class(grid_t),    pointer     :: zGrid
     class(grid_t),    pointer     :: lambdaGrid
@@ -86,9 +87,9 @@ contains
     nzdim = zGrid%ncells_ + 1
     modelDens = mdlDensity%edge_val_
 
-    allocate( quantum_yield( lambdaGrid%ncells_, nzdim ) )
+    allocate( wrkQuantumYield( lambdaGrid%ncells_, nzdim ) )
     allocate( quantum_yield_wrk( lambdaGrid%ncells_ ) )
-    quantum_yield = rZERO
+    wrkQuantumYield = rZERO
 
     quantum_yield_chnl1 = this%quantum_yield_parms(1)%array(:,2)
     quantum_yield_chnl2 = rONE - this%quantum_yield_parms(1)%array(:,1)
@@ -99,14 +100,14 @@ contains
     endwhere
     do vertNdx = 1,nzdim
       air_dens_factor = modelDens( vertNdx ) / 2.465e19_dk
-      quantum_yield( :, vertNdx ) =                                           &
+      wrkQuantumYield( :, vertNdx ) =                                         &
                       quantum_yield_chnl1 * ( rONE + quantum_yield_wrk )      &
                       / ( rONE + quantum_yield_wrk * air_dens_factor )
-      quantum_yield( :, vertNdx ) =                                           &
-          min( rONE, max( rZERO, quantum_yield( :, vertNdx ) ) )
+      wrkQuantumYield( :, vertNdx ) =                                         &
+          min( rONE, max( rZERO, wrkQuantumYield( :, vertNdx ) ) )
     enddo
 
-    quantum_yield = transpose( quantum_yield )
+    quantum_yield = transpose( wrkQuantumYield )
 
     deallocate( zGrid )
     deallocate( lambdaGrid )

--- a/src/quantum_yields/ch3coch2ch3-ch3co_ch2ch3.F90
+++ b/src/quantum_yields/ch3coch2ch3-ch3co_ch2ch3.F90
@@ -72,6 +72,7 @@ contains
 
     integer                       :: nzdim, vertNdx
     real(dk)                      :: ptorr
+    real(dk),         allocatable :: wrkQuantumYield(:,:)
     real(dk),         allocatable :: modelDens(:)
     class(grid_t),    pointer     :: zGrid
     class(grid_t),    pointer     :: lambdaGrid
@@ -84,16 +85,18 @@ contains
     nzdim = zGrid%ncells_ + 1
     modelDens = mdlDensity%edge_val_
 
-    allocate( quantum_yield( lambdaGrid%ncells_, nzdim ) )
-    quantum_yield = rZERO
+    allocate( wrkQuantumYield( lambdaGrid%ncells_, nzdim ) )
+    wrkQuantumYield = rZERO
 
     do vertNdx = 1, nzdim
       ptorr = 760._dk * modelDens( vertNdx ) / 2.69e19_dk
-      quantum_yield( :, vertNdx ) = rONE / ( 0.96_dk + 2.22E-3_dk * ptorr )
-      quantum_yield( :, vertNdx ) = min( quantum_yield( :, vertNdx ), rONE )
+      wrkQuantumYield( :, vertNdx ) =                                         &
+          rONE / ( 0.96_dk + 2.22E-3_dk * ptorr )
+      wrkQuantumYield( :, vertNdx ) =                                         &
+          min( wrkQuantumYield( :, vertNdx ), rONE )
     enddo
 
-    quantum_yield = transpose( quantum_yield )
+    quantum_yield = transpose( wrkQuantumYield )
 
     deallocate( zGrid )
     deallocate( lambdaGrid )

--- a/src/quantum_yields/ch3cocho.F90
+++ b/src/quantum_yields/ch3cocho.F90
@@ -75,6 +75,7 @@ contains
     integer                       :: nzdim, vertNdx
     integer                       :: lambdaNdx
     real(dk)                      :: phi0, kq, lambda, airfac, qy
+    real(dk),         allocatable :: wrkQuantumYield(:,:)
     real(dk),         allocatable :: modelDens(:)
     class(grid_t),    pointer     :: zGrid
     class(grid_t),    pointer     :: lambdaGrid
@@ -87,8 +88,8 @@ contains
     nzdim = zGrid%ncells_ + 1
     modelDens = mdlDensity%edge_val_
 
-    allocate( quantum_yield( lambdaGrid%ncells_, nzdim ) )
-    quantum_yield = rZERO
+    allocate( wrkQuantumYield( lambdaGrid%ncells_, nzdim ) )
+    wrkQuantumYield = rZERO
 
     ! zero pressure yield:
     ! 1.0 for wc < 380 nm
@@ -113,11 +114,11 @@ contains
         else
           qy = rZERO
         endif
-        quantum_yield( lambdaNdx, vertNdx ) = qy
+        wrkQuantumYield( lambdaNdx, vertNdx ) = qy
       enddo
     enddo
 
-    quantum_yield = transpose( quantum_yield )
+    quantum_yield = transpose( wrkQuantumYield )
 
     deallocate( zGrid )
     deallocate( lambdaGrid )

--- a/src/quantum_yields/clo-cl_o1d.F90
+++ b/src/quantum_yields/clo-cl_o1d.F90
@@ -68,6 +68,7 @@ contains
     real(dk), parameter ::    rZERO = 0.0_dk
     real(dk), parameter ::    rONE  = 1.0_dk
     integer                :: nzdim, vertNdx
+    real(dk), allocatable  :: wrkQuantumYield(:,:)
     class(grid_t), pointer :: zGrid
     class(grid_t), pointer :: lambdaGrid
 
@@ -76,18 +77,18 @@ contains
 
     nzdim = zGrid%ncells_ + 1
 
-    allocate( quantum_yield( lambdaGrid%ncells_, nzdim ) )
+    allocate( wrkQuantumYield( lambdaGrid%ncells_, nzdim ) )
 
     where( lambdaGrid%mid_ < 263.4_dk )
-      quantum_yield(:,1) = rONE
+      wrkQuantumYield(:,1) = rONE
     elsewhere
-      quantum_yield(:,1) = rZERO
+      wrkQuantumYield(:,1) = rZERO
     endwhere
     do vertNdx = 2, nzdim
-      quantum_yield( :, vertNdx ) = quantum_yield(:,1)
+      wrkQuantumYield( :, vertNdx ) = wrkQuantumYield(:,1)
     enddo
 
-    quantum_yield = transpose( quantum_yield )
+    quantum_yield = transpose( wrkQuantumYield )
 
     deallocate( zGrid )
     deallocate( lambdaGrid )

--- a/src/quantum_yields/clo-cl_o3p.F90
+++ b/src/quantum_yields/clo-cl_o3p.F90
@@ -68,6 +68,7 @@ contains
     real(dk), parameter ::    rZERO = 0.0_dk
     real(dk), parameter ::    rONE  = 1.0_dk
     integer                :: nzdim, vertNdx
+    real(dk), allocatable  :: wrkQuantumYield(:,:)
     class(grid_t), pointer :: zGrid
     class(grid_t), pointer :: lambdaGrid
 
@@ -76,18 +77,18 @@ contains
 
     nzdim = zGrid%ncells_ + 1
 
-    allocate( quantum_yield( lambdaGrid%ncells_, nzdim ) )
+    allocate( wrkQuantumYield( lambdaGrid%ncells_, nzdim ) )
 
     where( lambdaGrid%mid_ < 263.4_dk )
-      quantum_yield(:,1) = rZERO
+      wrkQuantumYield(:,1) = rZERO
     elsewhere
-      quantum_yield(:,1) = rONE
+      wrkQuantumYield(:,1) = rONE
     endwhere
     do vertNdx = 2, nzdim
-      quantum_yield( :, vertNdx ) = quantum_yield(:,1)
+      wrkQuantumYield( :, vertNdx ) = wrkQuantumYield(:,1)
     enddo
 
-    quantum_yield = transpose( quantum_yield )
+    quantum_yield = transpose( wrkQuantumYield )
 
     deallocate( zGrid )
     deallocate( lambdaGrid )

--- a/src/quantum_yields/clono2-cl_no3.F90
+++ b/src/quantum_yields/clono2-cl_no3.F90
@@ -71,6 +71,7 @@ contains
     integer                    :: vertNdx, lambdaNdx
     real(dk)                   :: lambda
     real(dk),      allocatable :: wrkQuantumYield(:)
+    real(dk),      allocatable :: wrkQuantumYield2D(:,:)
     class(grid_t), pointer     :: lambdaGrid
     class(grid_t), pointer     :: zGrid
 
@@ -78,7 +79,7 @@ contains
     lambdaGrid => grid_warehouse%get_grid( this%wavelength_grid_ )
 
     allocate( wrkQuantumYield( lambdaGrid%ncells_) )
-    allocate( quantum_yield( lambdaGrid%ncells_, zGrid%ncells_ + 1 ) )
+    allocate( wrkQuantumYield2D( lambdaGrid%ncells_, zGrid%ncells_ + 1 ) )
 
     do lambdaNdx = 1,lambdaGrid%ncells_
       lambda = lambdaGrid%mid_( lambdaNdx )
@@ -92,10 +93,10 @@ contains
     enddo
 
     do vertNdx = 1, zGrid%ncells_ + 1
-      quantum_yield( :, vertNdx ) = wrkQuantumYield
+      wrkQuantumYield2D( :, vertNdx ) = wrkQuantumYield
     enddo
 
-    quantum_yield = transpose( quantum_yield )
+    quantum_yield = transpose( wrkQuantumYield2D )
 
     deallocate( zGrid )
     deallocate( lambdaGrid )

--- a/src/quantum_yields/clono2-clo_no2.F90
+++ b/src/quantum_yields/clono2-clo_no2.F90
@@ -71,6 +71,7 @@ contains
     integer                    :: vertNdx, lambdaNdx
     real(dk)                   :: lambda
     real(dk),      allocatable :: wrkQuantumYield(:)
+    real(dk),      allocatable :: wrkQuantumYield2D(:,:)
     class(grid_t), pointer     :: lambdaGrid
     class(grid_t), pointer     :: zGrid
 
@@ -78,7 +79,7 @@ contains
     lambdaGrid => grid_warehouse%get_grid( this%wavelength_grid_ )
 
     allocate( wrkQuantumYield( lambdaGrid%ncells_ ) )
-    allocate( quantum_yield( lambdaGrid%ncells_, zGrid%ncells_ + 1 ) )
+    allocate( wrkQuantumYield2D( lambdaGrid%ncells_, zGrid%ncells_ + 1 ) )
 
     do lambdaNdx = 1, lambdaGrid%ncells_
       lambda = lambdaGrid%mid_( lambdaNdx )
@@ -92,10 +93,10 @@ contains
     enddo
 
     do vertNdx = 1, zGrid%ncells_ + 1
-      quantum_yield( :, vertNdx ) = rONE - wrkQuantumYield
+      wrkQuantumYield2D( :, vertNdx ) = rONE - wrkQuantumYield
     enddo
 
-    quantum_yield = transpose( quantum_yield )
+    quantum_yield = transpose( wrkQuantumYield2D )
 
     deallocate( zGrid )
     deallocate( lambdaGrid )

--- a/src/quantum_yields/ho2-oh_o.F90
+++ b/src/quantum_yields/ho2-oh_o.F90
@@ -72,12 +72,13 @@ contains
     class(grid_t), pointer :: lambdaGrid
     class(grid_t), pointer :: zGrid
     real(dk), allocatable  :: wrkQuantumYield(:)
+    real(dk), allocatable  :: wrkQuantumYield2D(:,:)
 
     zGrid => grid_warehouse%get_grid( this%height_grid_ )
     lambdaGrid => grid_warehouse%get_grid( this%wavelength_grid_ )
 
     allocate( wrkQuantumYield( lambdaGrid%ncells_ ) )
-    allocate( quantum_yield( lambdaGrid%ncells_, zGrid%ncells_ + 1 ) )
+    allocate( wrkQuantumYield2D( lambdaGrid%ncells_, zGrid%ncells_ + 1 ) )
 
     where( lambdaGrid%mid_ >= 248._dk )
       wrkQuantumYield = rONE
@@ -87,10 +88,10 @@ contains
     endwhere
     wrkQuantumYield = max( rZERO, wrkQuantumYield )
     do vertNdx = 1, zGrid%ncells_ + 1
-      quantum_yield( :, vertNdx ) = wrkQuantumYield
+      wrkQuantumYield2D( :, vertNdx ) = wrkQuantumYield
     enddo
 
-    quantum_yield = transpose( quantum_yield )
+    quantum_yield = transpose( wrkQuantumYield2D )
 
     deallocate( zGrid )
     deallocate( lambdaGrid )

--- a/src/quantum_yields/mvk.F90
+++ b/src/quantum_yields/mvk.F90
@@ -70,6 +70,7 @@ contains
 
     integer                       :: nzdim, vertNdx
     real(dk)                      :: divisor
+    real(dk),         allocatable :: wrkQuantumYield(:,:)
     real(dk),         allocatable :: modelDens(:)
     class(grid_t),    pointer     :: zGrid
     class(grid_t),    pointer     :: lambdaGrid
@@ -82,17 +83,18 @@ contains
     nzdim = zGrid%ncells_ + 1
     modelDens = mdlDensity%edge_val_
 
-    allocate( quantum_yield( lambdaGrid%ncells_, nzdim ) )
-    quantum_yield = rZERO
+    allocate( wrkQuantumYield( lambdaGrid%ncells_, nzdim ) )
+    wrkQuantumYield = rZERO
 
     do vertNdx = 1, nzdim
       divisor = 5.5_dk + 9.2e-19_dk * modelDens( vertNdx )
-      quantum_yield( :, vertNdx ) =                                           &
+      wrkQuantumYield( :, vertNdx ) =                                         &
           exp( -0.055_dk * ( lambdaGrid%mid_ - 308._dk ) ) / divisor
-      quantum_yield( :, vertNdx ) = min( quantum_yield( :, vertNdx ), rONE )
+      wrkQuantumYield( :, vertNdx ) =                                         &
+          min( wrkQuantumYield( :, vertNdx ), rONE )
     enddo
 
-    quantum_yield = transpose( quantum_yield )
+    quantum_yield = transpose( wrkQuantumYield )
 
     deallocate( zGrid )
     deallocate( lambdaGrid )

--- a/src/quantum_yields/no2_tint.F90
+++ b/src/quantum_yields/no2_tint.F90
@@ -122,8 +122,10 @@ contains
       call assert_msg( 167399246, nTemps >= nParms, Iam//'File: '//           &
                        trim( netcdfFiles( fileNdx )%to_char( ) )//            &
                        ' temperature array < number parameters' )
-      Qyield%deltaT = Qyield%temperature( 2 : nParms ) -                      &
-                        Qyield%temperature( 1 : nParms - 1 )
+      if( allocated( Qyield%deltaT ) ) deallocate( Qyield%deltaT )
+      allocate( Qyield%deltaT( nParms - 1 ) )
+      Qyield%deltaT(:) = Qyield%temperature( 2 : nParms ) -                   &
+                          Qyield%temperature( 1 : nParms - 1 )
       monopos = all( Qyield%deltaT > rZERO )
       if( .not. monopos ) then
         call assert_msg( 606144012, .not. any( Qyield%deltaT > rZERO ),       &
@@ -140,8 +142,10 @@ contains
               netcdf_obj%parameters( :, Ndxu )
           netcdf_obj%parameters( :, Ndxu ) = data_parameter
         enddo
-        Qyield%deltaT = Qyield%temperature( 2 : nParms ) -                    &
-                          Qyield%temperature( 1 : nParms - 1 )
+        if( allocated( Qyield%deltaT ) ) deallocate( Qyield%deltaT )
+        allocate( Qyield%deltaT( nParms - 1 ) )
+        Qyield%deltaT(:) = Qyield%temperature( 2 : nParms ) -                 &
+                            Qyield%temperature( 1 : nParms - 1 )
       endif
       ! interpolate from data to model wavelength grid
       if( allocated( netcdf_obj%wavelength ) ) then

--- a/src/quantum_yields/no3_aq.F90
+++ b/src/quantum_yields/no3_aq.F90
@@ -69,6 +69,7 @@ contains
     real(dk), parameter ::    rONE  = 1.0_dk
 
     integer                       :: nzdim, vertNdx
+    real(dk),         allocatable :: wrkQuantumYield(:,:)
     real(dk),         allocatable :: modelTemp(:)
     class(grid_t),    pointer     :: zGrid
     class(grid_t),    pointer     :: lambdaGrid
@@ -82,15 +83,15 @@ contains
     nzdim = zGrid%ncells_ + 1
     modelTemp = mdlTemperature%edge_val_
 
-    allocate( quantum_yield( lambdaGrid%ncells_, nzdim ) )
-    quantum_yield = rZERO
+    allocate( wrkQuantumYield( lambdaGrid%ncells_, nzdim ) )
+    wrkQuantumYield = rZERO
 
     do vertNdx = 1, nzdim
-      quantum_yield( :, vertNdx ) =                                           &
+      wrkQuantumYield( :, vertNdx ) =                                         &
         exp( -2400._dk / modelTemp(vertNdx) + 3.6_dk ) ! Chu & Anastasio, 2003
     enddo
 
-    quantum_yield = transpose( quantum_yield )
+    quantum_yield = transpose( wrkQuantumYield )
 
     deallocate( zGrid )
     deallocate( lambdaGrid )

--- a/src/quantum_yields/o3-o2_o1d.F90
+++ b/src/quantum_yields/o3-o2_o1d.F90
@@ -83,6 +83,7 @@ contains
     integer     :: wNdx, vertNdx
     real(dk)    :: kt, q1, q2, T300, lambda
     real(dk)    :: qfac1, qfac2
+    real(dk),         allocatable :: wrkQuantumYield(:,:)
     class(grid_t),    pointer :: lambdaGrid
     class(grid_t),    pointer :: zGrid
     class(profile_t), pointer :: temperature
@@ -91,8 +92,8 @@ contains
     lambdaGrid => grid_warehouse%get_grid( this%wavelength_grid_ )
     temperature => profile_warehouse%get_profile( this%temperature_profile_ )
 
-    allocate( quantum_yield( lambdaGrid%ncells_, zGrid%ncells_ + 1 ) )
-    quantum_yield = rZERO
+    allocate( wrkQuantumYield( lambdaGrid%ncells_, zGrid%ncells_ + 1 ) )
+    wrkQuantumYield = rZERO
 
     associate( w => lambdaGrid%mid_, Temp => temperature%edge_val_ )
 
@@ -105,14 +106,14 @@ contains
       T300 = Temp( vertNdx ) / 300._dk
 
       where( w(:) <= 305._dk )
-        quantum_yield( :, vertNdx ) = 0.90_dk
+        wrkQuantumYield( :, vertNdx ) = 0.90_dk
       elsewhere( w(:) > 328._dk .and. w(:) <= 340._dk )
-        quantum_yield( :, vertNdx ) = 0.08_dk
+        wrkQuantumYield( :, vertNdx ) = 0.08_dk
       endwhere
       do wNdx = 1, size( w )
         lambda = w( wNdx )
         if( lambda > 305._dk .and. lambda <= 328._dk ) then
-          quantum_yield( wNdx, vertNdx ) = 0.0765_dk                          &
+          wrkQuantumYield( wNdx, vertNdx ) = 0.0765_dk                        &
             + a(1) * qfac1 * EXP( -( (x(1) - lambda ) / om(1) )**4 )          &
             + a(2) * T300 * T300 * qfac2 *                                    &
                                      EXP( -( ( x(2) - lambda ) / om(2) )**2 ) &
@@ -123,7 +124,7 @@ contains
 
     end associate
 
-    quantum_yield = transpose( quantum_yield )
+    quantum_yield = transpose( wrkQuantumYield )
 
     deallocate( zGrid )
     deallocate( lambdaGrid )

--- a/src/quantum_yields/o3-o2_o3p.F90
+++ b/src/quantum_yields/o3-o2_o3p.F90
@@ -84,6 +84,7 @@ contains
     integer     :: wNdx, vertNdx
     real(dk)    :: kt, q1, q2, T300, lambda
     real(dk)    :: qfac1, qfac2
+    real(dk),         allocatable :: wrkQuantumYield(:,:)
     class(grid_t),    pointer :: lambdaGrid
     class(grid_t),    pointer :: zGrid
     class(profile_t), pointer :: temperature
@@ -92,8 +93,8 @@ contains
     lambdaGrid => grid_warehouse%get_grid( this%wavelength_grid_ )
     temperature => profile_warehouse%get_profile( this%temperature_profile_ )
 
-    allocate( quantum_yield( lambdaGrid%ncells_, zGrid%ncells_ + 1 ) )
-    quantum_yield = rZERO
+    allocate( wrkQuantumYield( lambdaGrid%ncells_, zGrid%ncells_ + 1 ) )
+    wrkQuantumYield = rZERO
 
     associate( w => lambdaGrid%mid_, Temp => temperature%edge_val_ )
 
@@ -106,14 +107,14 @@ contains
       T300 = Temp( vertNdx ) / 300._dk
 
       where( w(:) <= 305._dk )
-        quantum_yield( :, vertNdx ) = 0.90_dk
+        wrkQuantumYield( :, vertNdx ) = 0.90_dk
       elsewhere( w(:) > 328._dk .and. w(:) <= 340._dk )
-        quantum_yield( :, vertNdx ) = 0.08_dk
+        wrkQuantumYield( :, vertNdx ) = 0.08_dk
       endwhere
       do wNdx = 1, size(w)
         lambda = w( wNdx )
         if( lambda > 305._dk .and. lambda <= 328._dk ) then
-          quantum_yield( wNdx, vertNdx ) = 0.0765_dk                           &
+          wrkQuantumYield( wNdx, vertNdx ) = 0.0765_dk                        &
             + a(1) * qfac1 * EXP( -( ( x(1) - lambda ) / om(1) )**4 )          &
             + a(2) * T300 * T300 * qfac2 *                                     &
                                        EXP( -( (x(2) - lambda ) / om(2) )**2 ) &
@@ -124,7 +125,7 @@ contains
 
     end associate
 
-    quantum_yield = transpose( rONE - quantum_yield )
+    quantum_yield = transpose( rONE - wrkQuantumYield )
 
     deallocate( zGrid )
     deallocate( lambdaGrid )

--- a/src/quantum_yields/tint.F90
+++ b/src/quantum_yields/tint.F90
@@ -215,6 +215,7 @@ file_loop: &
     integer     :: nTemp
     integer     :: fileNdx, tNdx, vertNdx
     real(dk)    :: Tadj, Tstar
+    real(dk),         allocatable :: wrkQuantumYield(:,:)
     class(grid_t),    pointer :: lambdaGrid
     class(grid_t),    pointer :: zGrid
     class(profile_t), pointer :: temperature
@@ -225,9 +226,9 @@ file_loop: &
     lambdaGrid => grid_warehouse%get_grid( this%wavelength_grid_ )
     temperature => profile_warehouse%get_profile( this%temperature_profile_ )
 
-    allocate( quantum_yield(lambdaGrid%ncells_,zGrid%ncells_+1) )
+    allocate( wrkQuantumYield(lambdaGrid%ncells_,zGrid%ncells_+1) )
 
-    quantum_yield = rZERO
+    wrkQuantumYield = rZERO
 file_loop: &
     do fileNdx = 1, size( this%parameters )
       associate( Temp => this%parameters( fileNdx )%temperature,             &
@@ -243,7 +244,7 @@ file_loop: &
         enddo
         tNdx = tNdx - 1
         Tstar = ( Tadj - Temp( tNdx ) ) / wrkQyield%deltaT( tNdx )
-        quantum_yield( :, vertNdx ) = quantum_yield( :, vertNdx )             &
+        wrkQuantumYield( :, vertNdx ) = wrkQuantumYield( :, vertNdx )         &
                                     + wrkQyield%array(:,tNdx)                 &
                                     + Tstar * ( wrkQyield%array( :, tNdx + 1 )&
                                                 - wrkQyield%array( :, tNdx ) )
@@ -251,7 +252,7 @@ file_loop: &
       end associate
     enddo file_loop
 
-    quantum_yield = transpose( quantum_yield )
+    quantum_yield = transpose( wrkQuantumYield )
 
     deallocate( zGrid )
     deallocate( lambdaGrid )

--- a/src/quantum_yields/tint.F90
+++ b/src/quantum_yields/tint.F90
@@ -129,8 +129,10 @@ file_loop: &
                 ' temperature array < number parameters'
             call die_msg( 305276656, msg )
           endif
-          Qyield%deltaT = Qyield%temperature( 2 : nParms ) -                  &
-                            Qyield%temperature( 1 : nParms - 1 )
+          if( allocated( Qyield%deltaT ) ) deallocate( Qyield%deltaT )
+          allocate( Qyield%deltaT( nParms - 1 ) )
+          Qyield%deltaT(:) = Qyield%temperature( 2 : nParms ) -               &
+                              Qyield%temperature( 1 : nParms - 1 )
           monopos = all( Qyield%deltaT > rZERO )
           if( .not. monopos ) then
             if( any( Qyield%deltaT > rZERO ) ) then
@@ -149,8 +151,10 @@ file_loop: &
                   netcdf_obj%parameters( :, Ndxu )
               netcdf_obj%parameters( :, Ndxu ) = data_parameter
             enddo
-            Qyield%deltaT = Qyield%temperature( 2 : nParms ) -                &
-                              Qyield%temperature( 1 : nParms - 1 )
+            if( allocated( Qyield%deltaT ) ) deallocate( Qyield%deltaT )
+            allocate( Qyield%deltaT( nParms - 1 ) )
+            Qyield%deltaT(:) = Qyield%temperature( 2 : nParms ) -             &
+                                Qyield%temperature( 1 : nParms - 1 )
           endif
         else
           write(msg,*) Iam//'File: ',                                         &

--- a/src/radiative_transfer/radiator.F90
+++ b/src/radiative_transfer/radiator.F90
@@ -346,7 +346,7 @@ contains
     ! unique.
 
     class(radiator_state_t), intent(inout) :: this
-    class(radiator_ptr),     intent(in)    :: radiators(:)
+    type(radiator_ptr),      intent(in)    :: radiators(:)
 
     real(dk), parameter :: kfloor = 1.0_dk / largest ! smallest value for radiative properties
     real(dk), parameter :: kair_asym_factor = 0.1_dk
@@ -397,7 +397,10 @@ contains
     dscat_accum = max( dscat_accum, kfloor )
     dabs_accum  = max( dabs_accum, kfloor )
 
-    this%layer_OD_ = dscat_accum + dabs_accum
+    if( .not. allocated( this%layer_OD_ ) ) then
+      allocate( this%layer_OD_, mold = dscat_accum )
+    end if
+    this%layer_OD_(:,:) = dscat_accum + dabs_accum
     if( .not. allocated( this%layer_SSA_ ) ) then
       allocate( this%layer_SSA_, mold = this%layer_OD_ )
     end if

--- a/src/util/assert.F90
+++ b/src/util/assert.F90
@@ -53,7 +53,6 @@ contains
 
   !> Asserts condition to be true or fails with provided message
   subroutine assert_msg_string( code, condition, error_message )
-
     use musica_string,                 only : string_t
 
     !> Unique code for the assertion

--- a/src/util/assert.F90
+++ b/src/util/assert.F90
@@ -53,6 +53,7 @@ contains
 
   !> Asserts condition to be true or fails with provided message
   subroutine assert_msg_string( code, condition, error_message )
+
     use musica_string,                 only : string_t
 
     !> Unique code for the assertion

--- a/src/util/config.F90
+++ b/src/util/config.F90
@@ -641,11 +641,12 @@ contains
     integer(c_int) :: size, i
     type(string_t_c), pointer :: c_strings(:)
     logical(kind=c_bool) :: l_found
+    logical :: condition
 
     c_array = yaml_get_string_array_c( this%node_, to_c_string( key ),        &
                                        l_found )
-    call assert_msg( 469804765, l_found .or. present( default ) .or.          &
-                     present( found ), "Key '"//trim( key )//                 &
+    condition = l_found .or. present( default ) .or. present( found )
+    call assert_msg( 469804765, condition, "Key '"//trim( key )//                 &
                      "' requested by "//trim( caller )//" not found" )
     if( present( found ) ) then
       found = l_found
@@ -688,11 +689,12 @@ contains
     real(kind=c_double), pointer :: c_doubles(:)
     integer :: i
     logical(kind=c_bool) :: l_found
+    logical :: condition
 
-    c_array = yaml_get_double_array_c( this%node_, to_c_string( key ),        &
+    c_array = yaml_get_double_array_c( this%node_, to_c_string( key ),    &
                                        l_found )
-    call assert_msg( 507829003, l_found .or. present( default )               &
-                     .or. present( found ), "Key '"//trim( key )//            &
+    condition = l_found .or. present( default ) .or. present( found )
+    call assert_msg( 507829003, condition, "Key '"//trim( key )//         &
                      "' requested by "//trim( caller )//" not found" )
     if( present( found ) ) then
       found = l_found
@@ -733,11 +735,12 @@ contains
     type(c_ptr), pointer :: c_nodes(:)
     integer :: i
     logical(kind=c_bool) :: l_found
+    logical :: condition
 
     c_array = yaml_get_node_array_c( this%node_, to_c_string( key ), l_found )
-    call assert_msg( 737497064, l_found .or. present( default )               &
-                     .or. present( found ), "Key '"//trim( key )//            &
-                     "' requested by "//trim( caller )//" not found" )
+    condition = l_found .or. present( default ) .or. present( found )
+    call assert_msg( 737497064, condition, "Key '"//trim( key )// &
+                    "' requested by "//trim( caller )//" not found" )
     if( present( found ) ) then
       found = l_found
       if( .not. l_found .and. .not. present( default ) ) return

--- a/test/unit/radiator/radiator_test.F90
+++ b/test/unit/radiator/radiator_test.F90
@@ -77,8 +77,10 @@ program radiator_test
     use tuvx_radiator,                 only : radiator_ptr, radiator_state_t
 
     type(radiator_state_t) :: a_state, b_state, total_state
-    type(radiator_ptr)     :: radiators(2), one_radiator(1)
+    type(radiator_ptr), allocatable :: radiators(:), one_radiator(:)
 
+    allocate( radiators(2) )
+    allocate( one_radiator(1) )
     allocate( radiators(1)%val_ )
     allocate( radiators(2)%val_ )
     allocate( one_radiator(1)%val_ )

--- a/test/unit/test_utils.F90
+++ b/test/unit/test_utils.F90
@@ -117,6 +117,10 @@ contains
 
     integer :: i_level, i_wavelength
 
+    print *, "Checking 2D arrays with size ", size( results, dim = 1 ), " x ", &
+      size( results, dim = 2 )
+    print *, "Against expected results with size ", size( expected_results, dim = 1 ), &
+      " x ", size( expected_results, dim = 2 )
     call assert( 516187173, &
       size( results, dim = 1 ) == size( expected_results, dim = 1) )
     call assert( 963555019, &

--- a/test/unit/tuv_doug/schum.f
+++ b/test/unit/tuv_doug/schum.f
@@ -85,19 +85,19 @@ c     EXP(56.) = 2.091e24
       DO k=1,nz    !! loop for alt
          o2col1(k) = MAX(o2col(k),EXP(38.))
 
-         x  = ALOG(o2col1(k))
-         
-         IF (x .LT. 38.0) THEN
+         IF (o2col(k) .LT. EXP(38.)) THEN
             ktop1 = k-1
-            write(*,*) ktop1
             ktop  = MIN(ktop1,ktop)
-         ELSE IF (x .GT. 56.0) THEN
-            kbot = k
          ELSE
-            CALL effxs( x, tlev(k), xs )
-            DO i=1,17
-               o2xsk(k,i) = xs(i)
-            END DO
+            x  = ALOG(o2col1(k))
+            IF (x .GT. 56.0) THEN
+               kbot = k
+            ELSE
+               CALL effxs( x, tlev(k), xs )
+               DO i=1,17
+                  o2xsk(k,i) = xs(i)
+               END DO
+            ENDIF
          ENDIF
 
       END DO                    !! finish loop for alt

--- a/test/unit/util/io/netcdf.F90
+++ b/test/unit/util/io/netcdf.F90
@@ -64,27 +64,27 @@ contains
     call assert( 312726817, associated( my_file ) )
 
     ! check units
-    var_name = "foo"
+    var_name = string_t("foo")
     call assert( 600672797, my_file%variable_units( var_name, my_name )       &
                             .eq. "foobits" )
 
     ! check for variables
-    var_name = "foo"
+    var_name = string_t("foo")
     call assert( 745691162, my_file%exists( var_name, my_name ) )
     call assert( 852745200, .not. my_file%exists( "not there", my_name ) )
 
     ! scalar real
-    var_name = "qux"
+    var_name = string_t("qux")
     call my_file%read( var_name, real0D, my_name )
     call assert( 322376438, real0D .eq. 92.37_dk )
 
     ! scalar int
-    var_name = "quux"
+    var_name = string_t("quux")
     call my_file%read( var_name, int0D, my_name )
     call assert( 330171719, int0D .eq. 7 )
 
     ! unallocated 1D real
-    var_name = "foo"
+    var_name = string_t("foo")
     call my_file%read( var_name, real1D, my_name )
     call assert( 441036825, allocated( real1D ) )
     call assert( 442942359, size( real1D ) .eq. 4 )
@@ -96,7 +96,7 @@ contains
 
     ! pre-allocatted 1D real
     allocate( real1D( 3 ) )
-    var_name = "bar"
+    var_name = string_t("bar")
     call my_file%read( var_name, real1D, my_name )
     call assert( 329457898, allocated( real1D ) )
     call assert( 889144089, size( real1D ) .eq. 3 )
@@ -106,7 +106,7 @@ contains
     deallocate( real1D )
 
     ! unallocated 1D int
-    var_name = "quuz"
+    var_name = string_t("quuz")
     call my_file%read( var_name, int1D, my_name )
     call assert( 595878700, allocated( int1D ) )
     call assert( 820515390, size( int1D ) .eq. 4 )
@@ -118,7 +118,7 @@ contains
 
     ! pre-allocated 1D int
     allocate( int1D( 4 ) )
-    var_name = "quuz"
+    var_name = string_t("quuz")
     call my_file%read( var_name, int1D, my_name )
     call assert( 917493109, allocated( int1D ) )
     call assert( 182385707, size( int1D ) .eq. 4 )
@@ -129,7 +129,7 @@ contains
     deallocate( int1D )
 
     ! unallocated 2D real
-    var_name = "baz"
+    var_name = string_t("baz")
     call my_file%read( var_name, real2D, my_name )
     call assert( 910775563, allocated( real2D ) )
     call assert( 517887503, size( real2D, 1 ) .eq. 3 )
@@ -169,7 +169,7 @@ contains
     deallocate( real2D )
 
     ! 3D unallocated variable
-    var_name = "foobar"
+    var_name = string_t("foobar")
     call my_file%read( var_name, real3D, my_name )
     call assert( 628827846, allocated( real3D ) )
     call assert( 688571939, size( real3D, 1 ) .eq. 1 )
@@ -190,7 +190,7 @@ contains
     deallocate( real3D )
 
     ! 3D pre-allocated variable
-    var_name = "foobar"
+    var_name = string_t("foobar")
     allocate( real3D( 1, 3, 4 ) )
     call my_file%read( var_name, real3D, my_name )
     call assert( 506458779, allocated( real3D ) )
@@ -212,7 +212,7 @@ contains
     deallocate( real3D )
 
     ! 4D unallocated variable
-    var_name = "corge"
+    var_name = string_t("corge")
     call my_file%read( var_name, real4D, my_name )
     call assert( 464572470, allocated( real4D ) )
     call assert( 911940316, size( real4D, 1 ) .eq. 2 )
@@ -246,7 +246,7 @@ contains
     deallocate( real4D )
 
     ! 4D allocated variable
-    var_name = "corge"
+    var_name = string_t("corge")
     allocate( real4D( 2, 1, 3, 4 ) )
     call my_file%read( var_name, real4D, my_name )
     call assert( 493635311, allocated( real4D ) )
@@ -281,13 +281,13 @@ contains
     deallocate( real4D )
 
     ! dimension names
-    var_name = "qux"
+    var_name = string_t("qux")
     dim_names = my_file%variable_dimensions( var_name, my_name )
     call assert( 685336671, allocated( dim_names ) )
     call assert( 410031263, size( dim_names ) .eq. 0 )
     deallocate( dim_names )
 
-    var_name = "corge"
+    var_name = string_t("corge")
     dim_names = my_file%variable_dimensions( var_name, my_name )
     call assert( 513726528, allocated( dim_names ) )
     call assert( 562942007, size( dim_names ) .eq. 4 )
@@ -324,24 +324,24 @@ contains
     my_file => io_netcdf_t( file_name )
     call assert( 362264371, associated( my_file ) )
 
-    var_name = "qux"
+    var_name = string_t("qux")
     call my_file%write( var_name, 92.37_dk, my_name )
 
-    var_name = "foo"
-    dim_names(1) = "f"
-    units = "foobits"
+    var_name = string_t("foo")
+    dim_names(1) = string_t("f")
+    units = string_t("foobits")
     call my_file%write( var_name, dim_names(1),                               &
                         (/ 15.32_dk, 3.14_dk, 26.71_dk, 19.34_dk /), my_name )
     call my_file%set_variable_units( var_name, units, my_name )
 
-    var_name = "bar"
-    dim_names(1) = "g"
+    var_name = string_t("bar")
+    dim_names(1) = string_t("g")
     call my_file%write( var_name, dim_names(1),                               &
                         (/ 51.43_dk, 123.01_dk, 32.61_dk /), my_name )
 
-    var_name = "baz"
-    dim_names(1) = "g"
-    dim_names(2) = "f"
+    var_name = string_t("baz")
+    dim_names(1) = string_t("g")
+    dim_names(2) = string_t("f")
     allocate( real2D( 3, 4 ) )
     real2D(:,1) = (/ 31.2_dk, 41.3_dk, 623.34_dk /)
     real2D(:,2) = (/ 124.24_dk, 1592.3_dk, 42.53_dk /)
@@ -349,10 +349,10 @@ contains
     real2D(:,4) = (/ 51.64_dk, -61.7_dk, -423000.0_dk /)
     call my_file%write( var_name, dim_names(1:2), real2D, my_name )
 
-    var_name = "foobar"
-    dim_names(1) = "h"
-    dim_names(2) = "g"
-    dim_names(3) = "f"
+    var_name = string_t("foobar")
+    dim_names(1) = string_t("h")
+    dim_names(2) = string_t("g")
+    dim_names(3) = string_t("f")
     allocate( real3D( 1, 3, 4 ) )
     real3D(1,:,1) = (/ 532.123_dk, 1.5e+28_dk, 42.5_dk /)
     real3D(1,:,2) = (/ 39.25_dk, 4293.12_dk, 9753.231_dk /)
@@ -360,11 +360,11 @@ contains
     real3D(1,:,4) = (/ 84918000.0_dk, 13.2_dk, 8293.12_dk /)
     call my_file%write( var_name, dim_names(1:3), real3D, my_name )
 
-    var_name = "corge"
-    dim_names(1) = "i"
-    dim_names(2) = "h"
-    dim_names(3) = "g"
-    dim_names(4) = "f"
+    var_name = string_t("corge")
+    dim_names(1) = string_t("i")
+    dim_names(2) = string_t("h")
+    dim_names(3) = string_t("g")
+    dim_names(4) = string_t("f")
     allocate( real4D( 2, 1, 3, 4 ) )
     real4D(:,1,1,1) = (/ 532.123_dk, 632.123_dk /)
     real4D(:,1,2,1) = (/ 1.5e+28_dk, 2.5e+28_dk /)
@@ -380,11 +380,11 @@ contains
     real4D(:,1,3,4) = (/ 8293.12_dk, 9293.12_dk /)
     call my_file%write( var_name, dim_names(1:4), real4D, my_name )
 
-    var_name = "quux"
+    var_name = string_t("quux")
     call my_file%write( var_name, 7, my_name )
 
-    var_name = "quuz"
-    dim_names(1) = "f"
+    var_name = string_t("quuz")
+    dim_names(1) = string_t("f")
     call my_file%write( var_name, dim_names(1), (/ 9, 3, 12, 1 /), my_name )
 
     ! clean up
@@ -415,18 +415,18 @@ contains
     my_file => io_netcdf_t( file_name )
 
     ! 1D real
-    var_name = "foo"
-    append_dim = "f"
-    units = "foobits"
+    var_name = string_t("foo")
+    append_dim = string_t("f")
+    units = string_t("foobits")
     call my_file%append( var_name, units, append_dim, 1, 15.32_dk, my_name )
     call my_file%append( var_name, units, append_dim, 2, 3.14_dk,  my_name )
     call my_file%append( var_name, units, append_dim, 3, 26.71_dk, my_name )
     call my_file%append( var_name, units, append_dim, 4, 19.34_dk, my_name )
 
     ! 2D real
-    var_name = "baz"
-    append_dim = "f"
-    dim_names(1) = "g"
+    var_name = string_t("baz")
+    append_dim = string_t("f")
+    dim_names(1) = string_t("g")
     allocate( real1D( 3 ) )
     real1D(:) = (/ 31.2_dk, 41.3_dk, 623.34_dk /)
     call my_file%append( var_name, units, append_dim, 1, dim_names(1), real1D,&
@@ -443,10 +443,10 @@ contains
     deallocate( real1D )
 
     ! 3D real
-    var_name = "foobar"
-    append_dim   = "f"
-    dim_names(1) = "h"
-    dim_names(2) = "g"
+    var_name = string_t("foobar")
+    append_dim   = string_t("f")
+    dim_names(1) = string_t("h")
+    dim_names(2) = string_t("g")
     allocate( real2D( 1, 3 ) )
     real2D(1,:) = (/ 532.123_dk, 1.5e+28_dk, 42.5_dk /)
     call my_file%append( var_name, units, append_dim, 1, dim_names, real2D,   &
@@ -463,11 +463,12 @@ contains
     deallocate( real2D )
 
     ! 4D real
-    var_name = "corge"
-    append_dim   = "f"
-    dim_names(1) = "i"
-    dim_names(2) = "h"
-    dim_names(3) = "g"
+    var_name = string_t("corge")
+    append_dim   = string_t("f")
+    dim_names(1) = string_t("i")
+    dim_names(2) = string_t("h")
+    dim_names(3) = string_t("g")
+    dim_names(4) = string_t("f")
     allocate( real3D( 2, 1, 3 ) )
     real3D(:,1,1) = (/ 532.123_dk, 632.123_dk /)
     real3D(:,1,2) = (/ 1.5e+28_dk, 2.5e+28_dk /)
@@ -492,8 +493,8 @@ contains
     deallocate( real3D )
 
     ! 1D int
-    var_name = "quuz"
-    append_dim = "f"
+    var_name = string_t("quuz")
+    append_dim = string_t("f")
     call my_file%append( var_name, units, append_dim, 1, 9,  my_name )
     call my_file%append( var_name, units, append_dim, 2, 3,  my_name )
     call my_file%append( var_name, units, append_dim, 3, 12, my_name )
@@ -508,17 +509,17 @@ contains
     call assert( 829668994, associated( my_file ) )
 
     ! check units
-    var_name = "foo"
+    var_name = string_t("foo")
     call assert( 606937838, my_file%variable_units( var_name, my_name )       &
                             .eq. "foobits" )
 
     ! check for variables
-    var_name = "foo"
+    var_name = string_t("foo")
     call assert( 154305685, my_file%exists( var_name, my_name ) )
     call assert( 601673531, .not. my_file%exists( "not there", my_name ) )
 
     ! 1D real
-    var_name = "foo"
+    var_name = string_t("foo")
     call my_file%read( var_name, real1D, my_name )
     call assert( 214049778, allocated( real1D ) )
     call assert( 661417624, size( real1D ) .eq. 4 )
@@ -529,7 +530,7 @@ contains
     deallocate( real1D )
 
     ! 2D real
-    var_name = "baz"
+    var_name = string_t("baz")
     call my_file%read( var_name, real2D, my_name )
     call assert( 125066082, allocated( real2D ) )
     call assert( 919917577, size( real2D, 1 ) .eq. 4 )
@@ -549,7 +550,7 @@ contains
     deallocate( real2D )
 
     ! 3D variable
-    var_name = "foobar"
+    var_name = string_t("foobar")
     call my_file%read( var_name, real3D, my_name )
     call assert( 539636810, allocated( real3D ) )
     call assert( 704529407, size( real3D, 1 ) .eq. 4 )
@@ -570,7 +571,7 @@ contains
     deallocate( real3D )
 
     ! 4D variable
-    var_name = "corge"
+    var_name = string_t("corge")
     call my_file%read( var_name, real4D, my_name )
     call assert( 514219865, allocated( real4D ) )
     call assert( 344062961, size( real4D, 1 ) .eq. 4 )
@@ -604,7 +605,7 @@ contains
     deallocate( real4D )
 
     ! 1D int
-    var_name = "quuz"
+    var_name = string_t("quuz")
     call my_file%read( var_name, int1D, my_name )
     call assert( 250469612, allocated( int1D ) )
     call assert( 697837458, size( int1D ) .eq. 4 )


### PR DESCRIPTION
Fix all test and build failures with the nvhpc 25.7 compiler.
                                                                                                                                                                                         
- Add nvhpc Docker build and CI workflow                                 
- Fix self-referential transpose() on allocatable arrays (20 cross sections, 17 quantum yields)
- Fix array auto-reallocation preserving wrong lbounds for grid mid_/delta_ and profile layer_dens_/mid_val_/delta_val_
- Fix polymorphic array descriptor corruption in radiator_state_t%accumulate (class → type for non-extended radiator_ptr)
- Fix stack array corruption in radiator test by making arrays allocatable
- Fix allocatable function result in la_sr_bands%effxs by using fixed-size array
- Fix sequence association this%AC(1,I) → this%AC(:,I) in la_sr_bands%calc_params
- Fix log(exp(38)) roundoff misclassifying ktop boundary in Schumann-Runge bands (both TUV-x and F77 reference code)
- Fix string corruption in dose_rates constructor by replacing array concatenation [ handles_, key ] with explicit reallocation