### PR TITLE
Add plan for Copilot port to C++

### DIFF
--- a/.github/prompts/phase0-scaffolding.prompt.md
+++ b/.github/prompts/phase0-scaffolding.prompt.md
@@ -1,0 +1,198 @@
+# Phase 0: Project Scaffolding (Steps 1–3)
+
+See [master plan](plan-tuvXCppSolverRewrite.prompt.md) for overall architecture and key decisions.
+
+## Context
+
+We are creating a new standalone C++ library (`tuv-x-cpp`) to replace the Fortran-based TUV-x photolysis rate calculator. This phase sets up the new repo, migrates existing complete C++ code, and establishes the template policy system for CPU/GPU portability.
+
+## Step 1: Create new repository
+
+Create a new repo with:
+- CMake 3.21+ build system (matching MUSICA requirements)
+- Languages: `CXX` with optional `CUDA`/`HIP` support
+- Google Test and Google Benchmark as test/benchmark dependencies (FetchContent)
+- NetCDF-C as an optional dependency (for data readers)
+- Project name: `tuv-x` or `tuv-x-cpp`, aliased as `musica::tuvx`
+- Apache-2.0 license (matching MUSICA)
+
+Directory structure:
+```
+include/tuvx/          # Public headers
+src/                    # Implementation files
+test/unit/              # GTest unit tests
+test/regression/        # Regression tests against Fortran reference data
+benchmark/              # Google Benchmark files
+cmake/                  # CMake modules (dependencies, test utilities, coverage)
+data/                   # Reference data files (NetCDF)
+docker/                 # Dockerfiles for coverage, memcheck, compiler variants
+.github/workflows/      # CI workflow files
+.clang-format           # Formatting rules
+.clang-tidy             # Static analysis rules
+```
+
+### CI/CD Requirements (GitHub Actions)
+
+All of the following must be in place before any feature work begins.
+
+#### 1. Multi-compiler test matrix (PR gate — must pass to merge)
+
+Tests must pass with all major compilers on all three platforms:
+
+| OS | Compilers |
+|----|-----------|
+| Ubuntu (24.04) | GCC 12, 13, 14; Clang 17, 18 |
+| macOS (latest) | Apple Clang (Xcode default); GCC 14, 15 |
+| Windows (latest) | MSVC (latest via Visual Studio); MinGW GCC |
+| Docker (Linux) | Intel icx/icpx (oneAPI); NVIDIA nvc/nvc++ (NVHPC) |
+
+Build types: both `Debug` and `Release` for each compiler.
+
+#### 2. Code coverage (PR gate — >95% required)
+
+- Use lcov/gcov for GCC builds or llvm-cov for Clang builds
+- Coverage runs in a Docker container (like current `Dockerfile.coverage` pattern)
+- Upload to Codecov via `codecov/codecov-action`
+- **PR check must fail if line coverage drops below 95%** — configure via `codecov.yml`:
+  ```yaml
+  coverage:
+    status:
+      project:
+        default:
+          target: 95%
+          threshold: 1%
+      patch:
+        default:
+          target: 95%
+  ```
+- CMake flag: `-D TUVX_ENABLE_COVERAGE:BOOL=TRUE -D CMAKE_BUILD_TYPE=COVERAGE`
+
+#### 3. Memory checking with Valgrind (PR gate — must pass clean)
+
+- All unit and regression tests run under Valgrind memcheck
+- Runs in a Docker container (like current `Dockerfile.memcheck` pattern)
+- CMake flag: `-D TUVX_ENABLE_MEMCHECK:BOOL=TRUE -D CMAKE_BUILD_TYPE=DEBUG`
+- CTest wraps test executables with `valgrind --leak-check=full --error-exitcode=1`
+- **Any memory error fails the PR**
+
+#### 4. Static analysis with clang-tidy (PR gate — must pass clean)
+
+- Runs on every PR (unlike current repo where it's disabled)
+- Uses `.clang-tidy` config file at repo root
+- Recommended checks to enable:
+  ```yaml
+  Checks: >
+    bugprone-*,
+    cert-*,
+    clang-analyzer-*,
+    cppcoreguidelines-*,
+    misc-*,
+    modernize-*,
+    performance-*,
+    readability-*,
+    -modernize-use-trailing-return-type,
+    -readability-magic-numbers,
+    -cppcoreguidelines-avoid-magic-numbers
+  ```
+- Run against `include/` and `src/` using the compilation database (`compile_commands.json`)
+- **Any clang-tidy warning fails the PR** — no warnings-as-errors bypass
+
+#### 5. Auto-formatting PRs via clang-format (push to main only)
+
+- Triggered on pushes to `main` (not on PRs — to avoid circular triggers)
+- Runs `clang-format -i --style=file` on all `.hpp`, `.h`, `.cpp`, `.cc` files in `include/`, `src/`, `test/`
+- If changes are detected:
+  1. Commits with message `"Auto-format code using clang-format"`
+  2. Pushes to a `main-formatting` branch
+  3. Opens a PR via `peter-evans/create-pull-request@v6` back to `main`
+- `.clang-format` config should enforce the project style (recommend: based on LLVM or Google style, with project-specific overrides)
+
+#### 6. Concurrency and workflow organization
+
+- All workflows use concurrency groups to cancel superseded runs:
+  ```yaml
+  concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+  ```
+- Workflow files:
+  - `ubuntu.yml` — GCC + Clang matrix on Ubuntu
+  - `mac.yml` — Apple Clang + GCC on macOS
+  - `windows.yml` — MSVC + MinGW on Windows
+  - `docker.yml` — Intel, NVHPC, coverage, memcheck containers
+  - `clang-format.yml` — auto-formatting PRs
+  - `clang-tidy.yml` — static analysis PR gate
+
+### Naming Conventions
+
+The Fortran codebase is full of cryptic abbreviations (`edr_`, `eup_`, `fdr_`, `fdn_`, `sirrad`, `xsI`, `nTemp`, `vertNdx`, `rateNdx`, `Tadj`, `PSNDO`, `LINPACK`, etc.). The new codebase must prioritize legibility:
+
+- **Variables**: descriptive snake_case — `direct_irradiance`, `upwelling_flux`, `temperature_index`, `optical_depth_scaled`
+- **Types/Classes**: descriptive PascalCase — `RadiationField`, `TridiagonalMatrix`, `SphericalGeometry`
+- **Methods**: descriptive snake_case or camelCase (pick one, enforce via clang-tidy `readability-identifier-naming`)
+- **Template parameters**: PascalCase — `ArrayPolicy`, `ValueType`
+- **Constants**: `kPascalCase` or `SCREAMING_SNAKE_CASE`
+- **No single-letter variables** except loop indices (`i`, `j`, `k`) and well-known math symbols in formulas (e.g., `tau`, `omega`, `mu`, `gamma` — but spelled out, not `t`, `w`, `m`, `g`)
+- **No abbreviations** unless universally understood in the domain (e.g., `SSA` for single-scattering albedo is acceptable; `xs` for cross-section is not — use `cross_section`)
+- Configure `readability-identifier-naming` in `.clang-tidy` to enforce these conventions:
+  ```yaml
+  CheckOptions:
+    - key: readability-identifier-naming.ClassCase
+      value: CamelCase
+    - key: readability-identifier-naming.FunctionCase
+      value: camelBack
+    - key: readability-identifier-naming.VariableCase
+      value: lower_case
+    - key: readability-identifier-naming.ConstantCase
+      value: UPPER_CASE
+    - key: readability-identifier-naming.TemplateParameterCase
+      value: CamelCase
+  ```
+
+## Step 2: Migrate reusable C++ code
+
+Port these already-complete implementations from the current `tuv-x` repo:
+
+### Data structures
+- `Array2D<T>` — `include/tuvx/util/array2d.hpp`
+- `Array3D<T>` — `include/tuvx/util/array3d.hpp`
+- `Grid<ArrayPolicy>` — `include/tuvx/grid.hpp`
+- `Profile<ArrayPolicy>` — `include/tuvx/profile.hpp`
+- `RadiatorState<ArrayPolicy>` — `include/tuvx/radiative_transfer/radiator.hpp`
+- `RadiationField`, `RadiationFieldComponents` — `include/tuvx/radiative_transfer/radiation_field.hpp`
+
+### Linear algebra
+- `TridiagonalMatrix<T>`, `Solve()` — `include/tuvx/linear_algebra/linear_algebra.hpp`
+
+### Tests and benchmarks
+- GTest tests for Array2D, Array3D, Grid, Profile, TridiagonalSolver, ErrorFunction
+- Google Benchmark for tridiagonal solver — `benchmark/benchmark_tridiagonal_solver.cpp`
+
+Ensure all migrated tests pass in the new repo before proceeding.
+
+## Step 3: Define template policy system
+
+Extend the existing `ArrayPolicy` pattern. The key principle: **solver algorithms are written once**, templated on a single `ArrayPolicy`. From the algorithm's perspective, array access is identical regardless of backing storage.
+
+`ArrayPolicy` controls:
+- **Memory allocation**: where data lives (host heap, device memory)
+- **Data layout**: how elements are arranged (SoA with column index innermost)
+- **Element access**: syntax for reading/writing (identical API for host and device)
+
+Concrete policies to implement:
+- `HostArrayPolicy` — `std::vector`-backed; SoA layout for SIMD auto-vectorization
+- `DeviceArrayPolicy` — CUDA/HIP device memory; coalesced access; `__host__ __device__` accessors
+
+All core types (`Grid`, `Profile`, `RadiatorState`, `RadiationField`, `TridiagonalMatrix`) are already templated on `ArrayPolicy` — preserve and extend this pattern.
+
+## Existing C++ code to reference
+
+Key files in the current tuv-x repo:
+- `include/tuvx/util/array2d.hpp` — row-major 2D array
+- `include/tuvx/util/array3d.hpp` — row-major 3D array
+- `include/tuvx/grid.hpp` — multi-column grid with mid_points/edges
+- `include/tuvx/profile.hpp` — mid-point/edge values on a grid
+- `include/tuvx/radiative_transfer/radiator.hpp` — RadiatorState with optical_depth, SSA, asymmetry
+- `include/tuvx/radiative_transfer/radiation_field.hpp` — 3D arrays for direct/up/down flux
+- `include/tuvx/linear_algebra/linear_algebra.hpp` — Thomas algorithm tridiagonal solver
+- `test/unit/` — existing GTest files for the above

--- a/.github/prompts/phase0-scaffolding.prompt.md
+++ b/.github/prompts/phase0-scaffolding.prompt.md
@@ -154,6 +154,7 @@ The Fortran codebase is full of cryptic abbreviations (`edr_`, `eup_`, `fdr_`, `
 Port these already-complete implementations from the current `tuv-x` repo:
 
 ### Data structures
+- **`Array1D<T>` — new implementation** to create in `include/tuvx/util/array1d.hpp`, following the same pattern as `Array2D`/`Array3D`. This is a policy-aware 1D array that replaces `std::vector` in all interfaces that interact with policy-backed types (e.g., `Grid`, `Profile`, `RadiatorState`). When backed by `DeviceArrayPolicy`, data resides in device memory — `std::vector` cannot serve this role. Must support the same element access syntax as `Array2D`/`Array3D` via `ArrayPolicy`.
 - `Array2D<T>` — `include/tuvx/util/array2d.hpp`
 - `Array3D<T>` — `include/tuvx/util/array3d.hpp`
 - `Grid<ArrayPolicy>` — `include/tuvx/grid.hpp`
@@ -165,7 +166,7 @@ Port these already-complete implementations from the current `tuv-x` repo:
 - `TridiagonalMatrix<T>`, `Solve()` — `include/tuvx/linear_algebra/linear_algebra.hpp`
 
 ### Tests and benchmarks
-- GTest tests for Array2D, Array3D, Grid, Profile, TridiagonalSolver, ErrorFunction
+- GTest tests for Array1D (new), Array2D, Array3D, Grid, Profile, TridiagonalSolver, ErrorFunction
 - Google Benchmark for tridiagonal solver — `benchmark/benchmark_tridiagonal_solver.cpp`
 
 Ensure all migrated tests pass in the new repo before proceeding.
@@ -183,11 +184,12 @@ Concrete policies to implement:
 - `HostArrayPolicy` — `std::vector`-backed; SoA layout for SIMD auto-vectorization
 - `DeviceArrayPolicy` — CUDA/HIP device memory; coalesced access; `__host__ __device__` accessors
 
-All core types (`Grid`, `Profile`, `RadiatorState`, `RadiationField`, `TridiagonalMatrix`) are already templated on `ArrayPolicy` — preserve and extend this pattern.
+All core types (`Array1D`, `Grid`, `Profile`, `RadiatorState`, `RadiationField`, `TridiagonalMatrix`) are templated on `ArrayPolicy` — preserve and extend this pattern. `Array1D<T>` is new and must be created following the same conventions as `Array2D<T>` and `Array3D<T>`. **No `std::vector` should appear in any function signature that also accepts policy-backed types** — use `Array1D` instead to ensure correctness with device-resident data.
 
 ## Existing C++ code to reference
 
 Key files in the current tuv-x repo:
+- `include/tuvx/util/array1d.hpp` — policy-aware 1D array (**new — to be created**)
 - `include/tuvx/util/array2d.hpp` — row-major 2D array
 - `include/tuvx/util/array3d.hpp` — row-major 3D array
 - `include/tuvx/grid.hpp` — multi-column grid with mid_points/edges

--- a/.github/prompts/phase0-scaffolding.prompt.md
+++ b/.github/prompts/phase0-scaffolding.prompt.md
@@ -154,7 +154,7 @@ The Fortran codebase is full of cryptic abbreviations (`edr_`, `eup_`, `fdr_`, `
 Port these already-complete implementations from the current `tuv-x` repo:
 
 ### Data structures
-- **`Array1D<T>` — new implementation** to create in `include/tuvx/util/array1d.hpp`, following the same pattern as `Array2D`/`Array3D`. This is a policy-aware 1D array that replaces `std::vector` in all interfaces that interact with policy-backed types (e.g., `Grid`, `Profile`, `RadiatorState`). When backed by `DeviceArrayPolicy`, data resides in device memory — `std::vector` cannot serve this role. Must support the same element access syntax as `Array2D`/`Array3D` via `ArrayPolicy`.
+- **`Array1D<T>` — new implementation** to create in `include/tuvx/util/array1d.hpp`, following the same pattern as `Array2D`/`Array3D`. This is a policy-aware 1D array that replaces `std::vector` in all interfaces that interact with policy-backed types (e.g., `Grid`, `Profile`, `RadiatorState`). When backed by `DeviceArrayPolicy`, data resides in device memory — `std::vector` cannot serve this role. Must support the same element access syntax (`operator[]`), bulk operations (`ForEachRow`, `Function` factory), and dimension queries (`NumRows()`) as `Array2D`/`Array3D` via `ArrayPolicy`. Note: for `Array1D`, `ForEachRow` iterates element-wise (each element is a "row").
 - `Array2D<T>` — `include/tuvx/util/array2d.hpp`
 - `Array3D<T>` — `include/tuvx/util/array3d.hpp`
 - `Grid<ArrayPolicy>` — `include/tuvx/grid.hpp`
@@ -177,21 +177,37 @@ Extend the existing `ArrayPolicy` pattern. The key principle: **solver algorithm
 
 `ArrayPolicy` controls:
 - **Memory allocation**: where data lives (host heap, device memory)
-- **Data layout**: how elements are arranged (SoA with column index innermost)
-- **Element access**: syntax for reading/writing (identical API for host and device)
+- **Data layout**: how elements are physically arranged in memory (implementation-defined; optimized per target)
+- **Element access**: square-bracket syntax (`array[i][j]`, `array[i][j][k]`) for reading/writing by logical index (identical API for host and device)
 
 Concrete policies to implement:
-- `HostArrayPolicy` — `std::vector`-backed; SoA layout for SIMD auto-vectorization
-- `DeviceArrayPolicy` — CUDA/HIP device memory; coalesced access; `__host__ __device__` accessors
+- `HostArrayPolicy` — `std::vector`-backed; layout optimized for SIMD auto-vectorization
+- `DeviceArrayPolicy` — CUDA/HIP device memory; layout optimized for coalesced access; `__host__ __device__` accessors
 
 All core types (`Array1D`, `Grid`, `Profile`, `RadiatorState`, `RadiationField`, `TridiagonalMatrix`) are templated on `ArrayPolicy` — preserve and extend this pattern. `Array1D<T>` is new and must be created following the same conventions as `Array2D<T>` and `Array3D<T>`. **No `std::vector` should appear in any function signature that also accepts policy-backed types** — use `Array1D` instead to ensure correctness with device-resident data.
+
+### MICM-Consistent Bulk Operations API
+
+TUV-x array types must provide the same bulk operations API as MICM's `Matrix`/`VectorMatrix` types, since both are MUSICA components and a consistent interface reduces user friction. The API consists of:
+
+1. **Square-bracket element access**: `operator[]` chaining for logical indexing (e.g., `array[i][j]` for 2D). Returns proxy/view objects. Must match MICM's `matrix[row][col]` convention.
+
+2. **`ForEachRow(lambda, views...)`**: Layout-agnostic bulk iteration over all elements in a row (the solver's parallelization dimension). The policy controls vectorization/threading. Arguments are column views (`GetColumnView(col)` / `GetConstColumnView(col)`) and/or `Array1D` vectors.
+
+3. **`GetRowVariable()`**: Temporary per-row storage for intermediate calculations within `ForEachRow` chains.
+
+4. **`ArrayType<T>::Function(lambda, prototype_args...)`**: Factory that creates a reusable, policy-compiled function object. Pre-computes layout metadata at creation time. Column counts are validated at invocation; row counts may differ from the prototype. Matches MICM's `MatrixPolicy<T>::Function()` factory.
+
+5. **`NumRows()`, `NumColumns()`**: Dimension queries matching MICM naming.
+
+Solver hot paths **must** use `ForEachRow`/`Function` rather than element-by-element `operator[]` access — the bulk API is how the policy achieves vectorization/coalescing.
 
 ## Existing C++ code to reference
 
 Key files in the current tuv-x repo:
 - `include/tuvx/util/array1d.hpp` — policy-aware 1D array (**new — to be created**)
-- `include/tuvx/util/array2d.hpp` — row-major 2D array
-- `include/tuvx/util/array3d.hpp` — row-major 3D array
+- `include/tuvx/util/array2d.hpp` — 2D array with `operator[][]`, `ForEachRow`, `ColumnView`, `Function` factory (layout determined by policy)
+- `include/tuvx/util/array3d.hpp` — 3D array with `operator[][][]`, `ForEachRow`, `ColumnView`, `Function` factory (layout determined by policy)
 - `include/tuvx/grid.hpp` — multi-column grid with mid_points/edges
 - `include/tuvx/profile.hpp` — mid-point/edge values on a grid
 - `include/tuvx/radiative_transfer/radiator.hpp` — RadiatorState with optical_depth, SSA, asymmetry

--- a/.github/prompts/phase0-scaffolding.prompt.md
+++ b/.github/prompts/phase0-scaffolding.prompt.md
@@ -4,16 +4,16 @@ See [master plan](plan-tuvXCppSolverRewrite.prompt.md) for overall architecture 
 
 ## Context
 
-We are creating a new standalone C++ library (`tuv-x-cpp`) to replace the Fortran-based TUV-x photolysis rate calculator. This phase sets up the new repo, migrates existing complete C++ code, and establishes the template policy system for CPU/GPU portability.
+We are replacing the Fortran-based TUV-x photolysis rate calculator with a pure C++ implementation, working on a `cpp-rewrite` branch in the existing `tuv-x` repo. This phase sets up the branch, restructures existing C++ code, and establishes the template policy system for CPU/GPU portability.
 
-## Step 1: Create new repository
+## Step 1: Set up the `cpp-rewrite` branch
 
-Create a new repo with:
+Create a clean branch from `main` and remove Fortran source, legacy config files, and unused build scaffolding. Set up:
 - CMake 3.21+ build system (matching MUSICA requirements)
 - Languages: `CXX` with optional `CUDA`/`HIP` support
 - Google Test and Google Benchmark as test/benchmark dependencies (FetchContent)
 - NetCDF-C as an optional dependency (for data readers)
-- Project name: `tuv-x` or `tuv-x-cpp`, aliased as `musica::tuvx`
+- Project name: `tuv-x`, aliased as `musica::tuvx`
 - Apache-2.0 license (matching MUSICA)
 
 Directory structure:
@@ -169,7 +169,11 @@ Port these already-complete implementations from the current `tuv-x` repo:
 - GTest tests for Array1D (new), Array2D, Array3D, Grid, Profile, TridiagonalSolver, ErrorFunction
 - Google Benchmark for tridiagonal solver — `benchmark/benchmark_tridiagonal_solver.cpp`
 
-Ensure all migrated tests pass in the new repo before proceeding.
+Ensure all restructured tests pass on the `cpp-rewrite` branch before proceeding.
+
+### Documentation
+
+As code is restructured, add Doxygen `///` comments to every public class and function in `include/tuvx/`. Keep comments succinct: state what it does, what the parameters mean, and any preconditions. Omit `@author`, `@date`, `@file` boilerplate. For implementations ported from Fortran, reference the original subroutine/file.
 
 ## Step 3: Define template policy system
 

--- a/.github/prompts/phase1-deltaEddington.prompt.md
+++ b/.github/prompts/phase1-deltaEddington.prompt.md
@@ -66,5 +66,5 @@ For the new library: pre-compute Fortran reference outputs and store as binary/N
 
 Test configurations should include the standard examples:
 - `examples/tuv_5_4.json` — standard 156-wavelength, 120-layer US standard atmosphere
-- Multiple solar zenith angles (the existing test uses 1.8294° and 28.199°)
+- Multiple solar zenith angles (the existing Fortran test uses 1.8294° and 28.199°; C++ tests must specify these in radians: ~0.03194 rad and ~0.4922 rad)
 - Multiple columns (verify multi-column batching produces identical per-column results)

--- a/.github/prompts/phase1-deltaEddington.prompt.md
+++ b/.github/prompts/phase1-deltaEddington.prompt.md
@@ -1,0 +1,70 @@
+# Phase 1: Delta Eddington Solver (Steps 4–6)
+
+See [master plan](plan-tuvXCppSolverRewrite.prompt.md) for overall architecture and key decisions.
+
+## Context
+
+The Delta Eddington solver is the primary two-stream radiative transfer solver used for photolysis rate calculations. The Fortran implementation is ~468 lines. The C++ stub exists but `Solve()` is a placeholder returning dummy values. The algorithm follows Toon et al. (1989).
+
+## Step 4: Implement spherical geometry utilities
+
+Port from Fortran sources:
+- `src/spherical_geometry.F90` — pseudo-spherical geometry corrections
+- `src/radiative_transfer/solver.F90` — `slant_optical_depth` function
+
+These compute the effective solar path through curved atmospheric layers accounting for Earth's curvature. Implement as pure functions (no state). All inputs/outputs in SI units (meters, radians).
+
+## Step 5: Implement Delta Eddington solver
+
+Replace the placeholder in `include/tuvx/radiative_transfer/solvers/delta_eddington.inl` with the actual algorithm from `src/radiative_transfer/solvers/delta_eddington.F90`.
+
+### Algorithm (6 steps from Toon et al. 1989)
+
+**Step 1 — Delta-scale and compute gamma coefficients** (per layer, per wavelength, per column):
+
+$$\gamma_1^n = \frac{7 - \omega_0(4 + 3g_n)}{4}, \quad \gamma_2^n = \frac{-1 - \omega_0(4 - 3g_n)}{4}$$
+$$\gamma_3^n = \frac{2 - 3g_n\mu_0}{4}, \quad \gamma_4^n = 1 - \gamma_3^n$$
+$$\lambda_n = \sqrt{\gamma_1^2 - \gamma_2^2}, \quad \Gamma_n = \frac{\gamma_1^n - \lambda_n}{\gamma_2^n}$$
+
+**Step 2 — Solar source functions** $C^+(\tau)$ and $C^-(\tau)$:
+
+$$C^+(\tau) = \omega_0 \pi F_s e^{-\tau/\mu_0} \frac{(\gamma_1 - 1/\mu_0)\gamma_3 + \gamma_4\gamma_2}{\lambda^2 - 1/\mu_0^2}$$
+
+**Step 3 — Tridiagonal system coefficients** ($e_1$ through $e_4$; $A_n$, $B_n$, $D_n$ diagonals)
+
+**Step 4 — RHS assembly** ($E_n$) with surface albedo boundary condition
+
+**Step 5 — Solve tridiagonal system** using existing `TridiagonalMatrix::Solve()` (Thomas algorithm)
+
+**Step 6 — Back-substitute** $Y$ to compute fluxes and actinic flux:
+$$F_n^+ = Y_1^n e_1^n + Y_2^n e_2^n + C_n^+(\tau_n)$$
+$$F_n^- = Y_1^n e_3^n + Y_2^n e_4^n + C_n^-(\tau_n)$$
+
+### Implementation requirements
+
+- Template on `ArrayPolicy` — same algorithm for CPU and GPU
+- Process batches of columns; column dimension is innermost for SIMD/GPU vectorization
+- All units in SI (meters, radians, seconds)
+- Use existing `TridiagonalMatrix::Solve()` for step 5
+- Refer to [issue #64](https://github.com/NCAR/tuv-x/issues/64) sub-issues #102, #103, #104 for step-by-step breakdown
+
+### Key Fortran files to reference
+
+- `src/radiative_transfer/solvers/delta_eddington.F90` — the Fortran implementation (~468 lines)
+- `src/radiative_transfer/solver.F90` — base solver class with `slant_optical_depth`
+- `src/spherical_geometry.F90` — spherical geometry corrections
+- `src/linear_algebras/linpack.F90` — LINPACK tridiagonal solver (replaced by C++ Thomas algorithm)
+
+## Step 6: Regression test against Fortran solver
+
+Adapt the existing test harness in `test/regression/solvers/`:
+- `test/regression/solvers/delta_eddington.hpp` — C-interop structs (`SolverInput`/`SolverOutput`)
+- `test/regression/solvers/delta_eddington.cpp` — C++ wrapper that creates objects and calls solver
+- `test/regression/solvers/delta_eddington.F90` — Fortran test that runs full pipeline
+
+For the new library: pre-compute Fortran reference outputs and store as binary/NetCDF fixtures. The C++ tests load these fixtures and compare solver output within floating-point tolerance, decoupling from the Fortran build entirely.
+
+Test configurations should include the standard examples:
+- `examples/tuv_5_4.json` — standard 156-wavelength, 120-layer US standard atmosphere
+- Multiple solar zenith angles (the existing test uses 1.8294° and 28.199°)
+- Multiple columns (verify multi-column batching produces identical per-column results)

--- a/.github/prompts/phase1-deltaEddington.prompt.md
+++ b/.github/prompts/phase1-deltaEddington.prompt.md
@@ -72,3 +72,7 @@ Test configurations should include the standard examples:
 - `examples/tuv_5_4.json` — standard 156-wavelength, 120-layer US standard atmosphere
 - Multiple solar zenith angles (the existing Fortran test uses 1.8294° and 28.199°; C++ tests must specify these in radians: ~0.03194 rad and ~0.4922 rad)
 - Multiple columns (verify multi-column batching produces identical per-column results)
+
+### Documentation
+
+Document all public functions (spherical geometry utilities, `RadiationField`, `Solve()`) with Doxygen `///` comments as they are written. For each ported algorithm, reference the Fortran subroutine name and source file. Keep comments succinct — state what the function does and its preconditions, not a line-by-line translation of the algorithm.

--- a/.github/prompts/phase1-deltaEddington.prompt.md
+++ b/.github/prompts/phase1-deltaEddington.prompt.md
@@ -43,7 +43,11 @@ $$F_n^- = Y_1^n e_3^n + Y_2^n e_4^n + C_n^-(\tau_n)$$
 ### Implementation requirements
 
 - Template on `ArrayPolicy` — same algorithm for CPU and GPU
-- Process batches of columns; column dimension is innermost for SIMD/GPU vectorization
+- Use the **bulk operations API** (`ForEachRow`, `ColumnView`, `Function` factory) for all hot-path computation — no explicit loops over columns
+- Create `ArrayPolicy::Function` objects for the per-timestep solver steps (gamma computation, source functions, tridiagonal assembly, back-substitution) so the policy can pre-compile optimized iteration patterns
+- Use `GetColumnView()` / `GetConstColumnView()` for accessing per-column data within `ForEachRow` lambdas
+- Use `GetRowVariable()` for intermediate per-row temporaries ($\lambda_n$, $\Gamma_n$, $C^+$, $C^-$)
+- Process batches of columns; the `ArrayPolicy` determines the optimal data layout for parallelization across columns
 - All units in SI (meters, radians, seconds)
 - Use existing `TridiagonalMatrix::Solve()` for step 5
 - Refer to [issue #64](https://github.com/NCAR/tuv-x/issues/64) sub-issues #102, #103, #104 for step-by-step breakdown

--- a/.github/prompts/phase2-transforms.prompt.md
+++ b/.github/prompts/phase2-transforms.prompt.md
@@ -4,7 +4,7 @@ See [master plan](plan-tuvXCppSolverRewrite.prompt.md) for overall architecture 
 
 ## Context
 
-The current Fortran codebase has 27 cross-section types, 20 quantum yield types, and 12 spectral weight types, each implemented as a separate class with a factory pattern. Analysis shows these decompose into ~8 recurring mathematical patterns. The new library replaces this with composable lambda-based transforms configured via a programmatic C++ API (no config files — MUSICA handles configuration).
+The current Fortran codebase has 27 cross-section types, 20 quantum yield types, and 12 spectral weight types, each implemented as a separate class with a factory pattern. Analysis shows these decompose into ~8 recurring mathematical patterns. The new library defines an open `TransformFunc` API — any lambda or callable matching the signature is a valid transform. A convenience library of pre-built factory functions covers the common patterns, and combinators allow composing transforms. Users can mix library-provided factories, combinators, and raw user-written lambdas freely. No config files — MUSICA handles configuration.
 
 ## Step 7: Design the transform type system
 
@@ -22,52 +22,77 @@ using TransformFunc = std::function<void(
 )>;
 ```
 
-This is the universal signature for cross-sections, quantum yields, and spectral weights. The output includes the column dimension because temperature, pressure, and density vary per column, so the computed values differ per column.
+**`TransformFunc` is the open, user-facing API.** Any callable matching this signature is a valid transform. Users can write raw lambdas, function objects, or free functions directly — no factory or wrapper is required:
+
+```cpp
+// User-written transform — just a lambda matching the TransformFunc signature:
+TransformFunc<ArrayPolicy> rayleigh_xs = [](const auto& wl_grid, const auto& alt_grid,
+    const auto& temperature, const auto& pressure, const auto& air_density, auto& output) {
+    // Rayleigh scattering formula using ForEachRow, ColumnView, etc.
+    // This IS the transform — no wrapper needed.
+};
+```
+
+The output includes the column dimension because temperature, pressure, and density vary per column, so the computed values differ per column.
 
 Transform implementations should use the **bulk operations API** (`ForEachRow`, `ColumnView`, `Function`) for all per-element computation. For transforms computed from static reference data (loaded via `DataReader`), the reference data is broadcast into the per-column output using `ForEachRow`. Performance-critical transforms (called every timestep) should return pre-compiled `ArrayPolicy::Function` objects.
 
-## Step 8: Implement composable transform primitives
+## Step 8: Implement convenience transform library
 
-Each primitive is a factory function returning a `TransformFunc`:
+Provide a library of pre-built factory functions that return `TransformFunc` callables. These are **convenience utilities built on the same public API a user would use** — they capture parameters and return a lambda matching the `TransformFunc` signature. Users can use these off-the-shelf, compose them with combinators (Step 9), or ignore them entirely and write raw lambdas.
 
-| Primitive | Math | Replaces (Fortran types) |
-|-----------|------|--------------------------|
-| `from_data(reader, interpolator)` | Tabulated data → model grid interpolation | Base `cross_section_t`, base `quantum_yield_t` |
-| `temperature_interpolation(reader)` | $\sigma(\lambda,T) = \sigma_i + \frac{T-T_i}{T_{i+1}-T_i}(\sigma_{i+1}-\sigma_i)$ | `tint` xs, `tint` qy, `NO2 tint`, `O3 tint` |
+### Factory functions (each returns a `TransformFunc`)
+
+| Factory function | Math | Useful for |
+|-----------|------|---------------------------|
+| `from_data(reader, interpolator)` | Tabulated data → model grid interpolation | Base cross-sections, quantum yields |
+| `temperature_interpolation(reader)` | $\sigma(\lambda,T) = \sigma_i + \frac{T-T_i}{T_{i+1}-T_i}(\sigma_{i+1}-\sigma_i)$ | T-dependent tint types |
 | `polynomial_scaling(coeffs, T_ref)` | $\sigma_0 \cdot P(T-T_{ref}, \lambda)$ | CCl4, acetone, ClONO2, HCFC |
 | `exponential_scaling(coeffs, T_ref)` | $\sigma_0 \cdot \exp(f(T,\lambda))$ | CFC-11, RONO2, N2O5, CHBr3, CH3ONO2 |
 | `linear_correction(slope_data)` | $\sigma_0 + \beta \cdot \Delta T$ | CH2O |
-| `analytic(lambda_expr)` | User-supplied lambda | Rayleigh, nitroxy acetone, nitroxy ethanol |
-| `stern_volmer(phi0, k)` | $\phi = 1/(1/\phi_0 + k \cdot M)$ | CH2O quantum yield |
-| `parameterized(type, params)` | Taylor series, Burkholder, Harwood strategies | `temperature_based` xs |
+| `stern_volmer(phi0, k)` | $\phi = 1/(1/\phi_0 + k \cdot M)$ | Quenching quantum yields |
+| `parameterized(type, params)` | Taylor series, Burkholder, Harwood strategies | T-parameterized cross-sections |
+
+### Signature adapter
+
+| Adapter | Purpose |
+|---------|---------|
+| `wrap_analytic(f)` | Takes a simple `f(λ)→double` or `f(λ,T)→double` and wraps it into the full `TransformFunc` signature, handling grid iteration and column broadcasting internally. Useful for quick one-liner formulas. |
+
+`wrap_analytic` is a convenience for simple formulas — it is **not** the primary way to create custom transforms. For anything beyond a trivial formula, users should write a full `TransformFunc` lambda directly.
 
 ## Step 9: Implement transform combinators
+
+Combinators are higher-order functions: they take one or more `TransformFunc` values and return a new `TransformFunc`. They work with **any** transform — library-provided factories or user-written lambdas:
 
 | Combinator | Semantics |
 |------------|-----------|
 | `in_region(λ_min, λ_max, t)` | Apply `t` only where λ_min ≤ λ ≤ λ_max; zero outside |
-| `compose(base, modifier)` | `output = base * modifier` or `base + modifier` |
+| `multiply(a, b)` | Run both transforms, multiply their outputs element-wise |
+| `add(a, b)` | Run both transforms, add their outputs element-wise |
 | `piecewise({regions...})` | Different transforms per wavelength region |
 | `clamp(t, min, max)` | Clamp output values |
 | `override_band(name, value, t)` | Replace values in named bands (Lyman-α, Schumann-Runge) |
 | `scale(factor, t)` | Multiply by constant |
 
+**Why combinators instead of sequential application?** A `TransformFunc` *writes* to the output array — it doesn't modify an existing value. Applying two transforms in sequence would just overwrite the first result with the second. Combinators like `multiply(a, b)` internally run both transforms (one into the output, one into a temporary), then combine the results element-wise.
+
 ## Step 10: Port cross-section algorithms
 
-Express each of the 27 Fortran cross-section types as compositions. Reference files in `src/cross_sections/`:
+Express each of the 27 Fortran cross-section types as either a library factory, a composition of factories via combinators, or a user-written `TransformFunc` lambda. Reference files in `src/cross_sections/`:
 
-### Simple cases (direct primitive mapping)
+### Simple cases (direct factory mapping)
 - `base` → `from_data(reader, conserving_interpolator())`
 - `tint` → `temperature_interpolation(reader)`
-- `CCl4` → `compose(from_data(...), in_region(194e-9, 250e-9, polynomial_scaling(...)))`
-- `CFC-11` → `compose(from_data(...), exponential_scaling(...))`
-- `CH2O` → `compose(from_data(...), linear_correction(slope_data))`
-- `Rayleigh` → `analytic([](λ) { ... })` — Rayleigh scattering formula with λ in meters
+- `CCl4` → `multiply(from_data(...), in_region(194e-9, 250e-9, polynomial_scaling(...)))`
+- `CFC-11` → `multiply(from_data(...), exponential_scaling(...))`
+- `CH2O` → `add(from_data(...), linear_correction(slope_data))`
+- `Rayleigh` → `wrap_analytic([λ]{ ... })` or a direct `TransformFunc` lambda — Rayleigh scattering formula with λ in meters
 
-### Complex cases (multi-region / custom logic)
-- `O3` → `piecewise({<185e-9: data1, 185e-9–195e-9: data2, 195e-9–345e-9: tint, >345e-9: data4})` with refraction correction
-- `H2O2` → blended polynomial via Boltzmann χ — use `analytic()` with custom lambda
-- `acetone` → Horner polynomial in temperature
+### Complex cases (user-written lambdas or mixed compositions)
+- `O3` → `piecewise({<185e-9: data1, 185e-9–195e-9: data2, 195e-9–345e-9: tint, >345e-9: data4})` with refraction correction — the refraction correction can be a user-written `TransformFunc` lambda
+- `H2O2` → blended polynomial via Boltzmann χ — write as a direct `TransformFunc` lambda
+- `acetone` → Horner polynomial in temperature — write as a direct `TransformFunc` lambda or use `polynomial_scaling`
 
 ### Fortran source files to reference
 All in `src/cross_sections/`: `tint.F90`, `temperature_based.F90`, `no2_tint.F90`, `o3_tint.F90`, `rayliegh.F90`, `ccl4.F90`, `cfc-11.F90`, `ch2o.F90`, `h2o2-oh_oh.F90`, `hno3-oh_no2.F90`, `n2o5-no2_no3.F90`, `clono2.F90`, `hobr-oh_br.F90`, `hcfc.F90`, `chbr3.F90`, `chcl3.F90`, `cl2-cl_cl.F90`, `rono2.F90`, `t_butyl_nitrate.F90`, `acetone-ch3co_ch3.F90`, `ch3ono2-ch3o_no2.F90`, `nitroxy_acetone.F90`, `nitroxy_ethanol.F90`, `n2o-n2_o1d.F90`, `oclo.F90`
@@ -76,17 +101,17 @@ Temperature parameterization utilities in `src/cross_sections/util/`: `temperatu
 
 ## Step 11: Port quantum yield algorithms
 
-~20 types in `src/quantum_yields/`. Most map directly to existing primitives:
+~20 types in `src/quantum_yields/`. Most map to library factories, combinators, or direct `TransformFunc` lambdas:
 
-| Fortran type | Composed transform |
+| Fortran type | Transform |
 |--------------|-------------------|
 | `base` | `from_data(...)` or constant value |
 | `tint`, `NO2 tint` | `temperature_interpolation(...)` |
 | `CH2O` | `stern_volmer(phi0, k)` in region 330e-9–360e-9 m |
-| `taylor series` | `analytic(polynomial_lambda)` with clamp(0,1) |
-| `O3→O(1D)` | `analytic(matsumi_formula)` — multi-region Gaussians |
-| `H2SO4 Mills` | `analytic(mean_free_path_formula)` |
-| `acetone` | `analytic(blitz_parameterization)` |
+| `taylor series` | direct `TransformFunc` lambda with clamp(0,1) |
+| `O3→O(1D)` | direct `TransformFunc` lambda — multi-region Gaussians (Matsumi formula) |
+| `H2SO4 Mills` | direct `TransformFunc` lambda — mean free path formula |
+| `acetone` | direct `TransformFunc` lambda — Blitz parameterization |
 
 ## Step 12: Port spectral weight algorithms
 
@@ -95,8 +120,8 @@ Temperature parameterization utilities in `src/cross_sections/util/`: `temperatu
 | Fortran type | Transform |
 |-------------|-----------|
 | `base` | `from_data(reader, conserving_interpolator())` |
-| `gaussian` | `analytic([](λ, μ) { return exp(-ln2 * 0.04 * (λ-μ)²); })` |
-| `notch_filter` | `in_region(λ_min, λ_max, analytic([](λ) { return 1.0; }))` |
-| `exp_decay` | `analytic([](λ) { return pow(10, (300e-9-λ)/14e-9); })` |
+| `gaussian` | `wrap_analytic([](λ, μ) { return exp(-ln2 * 0.04 * (λ-μ)²); })` |
+| `notch_filter` | `in_region(λ_min, λ_max, constant(1.0))` |
+| `exp_decay` | `wrap_analytic([](λ) { return pow(10, (300e-9-λ)/14e-9); })` |
 | `PAR` | `in_region(400e-9, 700e-9, constant(1.0))` |
 | Others | Literature-specific analytic formulas |

--- a/.github/prompts/phase2-transforms.prompt.md
+++ b/.github/prompts/phase2-transforms.prompt.md
@@ -6,7 +6,7 @@ See [master plan](plan-tuvXCppSolverRewrite.prompt.md) for overall architecture 
 
 The current Fortran codebase has 27 cross-section types, 20 quantum yield types, and 12 spectral weight types, each implemented as a separate class with a factory pattern. Analysis shows these decompose into ~8 recurring mathematical patterns.
 
-**What is a transform?** A transform is a set of per-wavelength, per-height weights `[λ × z × col]` — conceptually a weight matrix that can be *applied* to the radiation field via element-wise multiplication. Cross-sections, quantum yields, and spectral weights are all transforms. The weight values may depend on atmospheric conditions (T, P, density), but those are inputs to the *weight calculation*, not to the application. The pipeline is: **calculate** the transform (produce the weight matrix) → **apply** it to the radiation field (multiply) → **reduce** (sum over wavelengths) to get rates (Phase 3).
+**What is a transform?** A transform is a set of per-wavelength, per-height weights `[λ × z × col]` — conceptually a weight matrix that can be *applied* to the radiation field via element-wise multiplication. Cross-sections, quantum yields, and spectral weights are all transforms. The weight values may depend on atmospheric state (T, P, density, constituent concentrations, etc.), but those are inputs to the *weight calculation*, not to the application. The pipeline is: **calculate** the transform (produce the weight matrix) → **apply** it to the radiation field (multiply) → **reduce** (sum over wavelengths) to get rates (Phase 3).
 
 The new library defines an open `TransformFunc` API — any lambda or callable matching the signature can *calculate* a transform. A convenience library of pre-built factory functions covers the common weight-calculation patterns, and combinators allow composing weight calculations. Users can mix library-provided factories, combinators, and raw user-written lambdas freely. No config files — MUSICA handles configuration.
 
@@ -17,27 +17,25 @@ Define `TransformFunc` as a callable that **calculates** a transform — i.e., f
 ```cpp
 template<typename ArrayPolicy>
 using TransformFunc = std::function<void(
-    const Grid<ArrayPolicy>& wavelength_grid,
-    const Grid<ArrayPolicy>& altitude_grid,
-    const Profile<ArrayPolicy>& temperature,
-    const Profile<ArrayPolicy>& pressure,
-    const Profile<ArrayPolicy>& air_density,
-    Array3D<typename ArrayPolicy::value_type>& weights  // [λ × z × col] — the calculated transform
+    const AtmosphericState<ArrayPolicy>& state,          // grids, T, P, density, constituents, etc.
+    Array3D<typename ArrayPolicy::value_type>& weights   // [λ × z × col] — the calculated transform
 )>;
 ```
+
+`TransformFunc` takes a single `AtmosphericState` rather than individual parameters so the signature is stable — adding new state fields (e.g., constituent concentrations for quenching yields) doesn't break existing transforms.
 
 **`TransformFunc` is the open, user-facing API.** Any callable matching this signature is a valid transform calculator. Users can write raw lambdas, function objects, or free functions directly — no factory or wrapper is required:
 
 ```cpp
 // User-written transform — just a lambda that calculates weights:
-TransformFunc<ArrayPolicy> rayleigh_xs = [](const auto& wl_grid, const auto& alt_grid,
-    const auto& temperature, const auto& pressure, const auto& air_density, auto& weights) {
+TransformFunc<ArrayPolicy> rayleigh_xs = [](const auto& state, auto& weights) {
+    // Access state.wavelength_grid, state.temperature, state.pressure, etc.
     // Calculate Rayleigh scattering weights using ForEachRow, ColumnView, etc.
     // The resulting weights will later be applied to the radiation field.
 };
 ```
 
-The weights include the column dimension because temperature, pressure, and density vary per column, so the calculated weights differ per column. The weights are later *applied* to the radiation field (element-wise multiplication) in Phase 3 (rate calculation).
+The weights include the column dimension because atmospheric state varies per column, so the calculated weights differ per column. The weights are later *applied* to the radiation field (element-wise multiplication) in Phase 3 (rate calculation).
 
 Transform implementations should use the **bulk operations API** (`ForEachRow`, `ColumnView`, `Function`) for all per-element computation. For transforms calculated from static reference data (loaded via `DataReader`), the reference data is broadcast into the per-column weights using `ForEachRow`. Performance-critical transforms (calculated every timestep) should return pre-compiled `ArrayPolicy::Function` objects.
 
@@ -49,6 +47,7 @@ Provide a library of pre-built factory functions that return `TransformFunc` cal
 
 | Factory function | Math | Useful for |
 |-----------|------|---------------------------|
+| `constant(value)` | Sets all weights to a single value | Flat quantum yields, unit weights |
 | `from_data(reader, interpolator)` | Tabulated data → model grid interpolation | Base cross-sections, quantum yields |
 | `temperature_interpolation(reader)` | $\sigma(\lambda,T) = \sigma_i + \frac{T-T_i}{T_{i+1}-T_i}(\sigma_{i+1}-\sigma_i)$ | T-dependent tint types |
 | `polynomial_scaling(coeffs, T_ref)` | $\sigma_0 \cdot P(T-T_{ref}, \lambda)$ | CCl4, acetone, ClONO2, HCFC |

--- a/.github/prompts/phase2-transforms.prompt.md
+++ b/.github/prompts/phase2-transforms.prompt.md
@@ -57,13 +57,13 @@ Express each of the 27 Fortran cross-section types as compositions. Reference fi
 ### Simple cases (direct primitive mapping)
 - `base` → `from_data(reader, conserving_interpolator())`
 - `tint` → `temperature_interpolation(reader)`
-- `CCl4` → `compose(from_data(...), in_region(194nm, 250nm, polynomial_scaling(...)))`
+- `CCl4` → `compose(from_data(...), in_region(194e-9, 250e-9, polynomial_scaling(...)))`
 - `CFC-11` → `compose(from_data(...), exponential_scaling(...))`
 - `CH2O` → `compose(from_data(...), linear_correction(slope_data))`
-- `Rayleigh` → `analytic([](λ) { return 4.02e-28 / pow(λ, p(λ)); })`
+- `Rayleigh` → `analytic([](λ) { ... })` — Rayleigh scattering formula with λ in meters
 
 ### Complex cases (multi-region / custom logic)
-- `O3` → `piecewise({<185nm: data1, 185-195nm: data2, 195-345nm: tint, >345nm: data4})` with refraction correction
+- `O3` → `piecewise({<185e-9: data1, 185e-9–195e-9: data2, 195e-9–345e-9: tint, >345e-9: data4})` with refraction correction
 - `H2O2` → blended polynomial via Boltzmann χ — use `analytic()` with custom lambda
 - `acetone` → Horner polynomial in temperature
 
@@ -80,7 +80,7 @@ Temperature parameterization utilities in `src/cross_sections/util/`: `temperatu
 |--------------|-------------------|
 | `base` | `from_data(...)` or constant value |
 | `tint`, `NO2 tint` | `temperature_interpolation(...)` |
-| `CH2O` | `stern_volmer(phi0, k)` in region 330–360nm |
+| `CH2O` | `stern_volmer(phi0, k)` in region 330e-9–360e-9 m |
 | `taylor series` | `analytic(polynomial_lambda)` with clamp(0,1) |
 | `O3→O(1D)` | `analytic(matsumi_formula)` — multi-region Gaussians |
 | `H2SO4 Mills` | `analytic(mean_free_path_formula)` |
@@ -95,6 +95,6 @@ Temperature parameterization utilities in `src/cross_sections/util/`: `temperatu
 | `base` | `from_data(reader, conserving_interpolator())` |
 | `gaussian` | `analytic([](λ, μ) { return exp(-ln2 * 0.04 * (λ-μ)²); })` |
 | `notch_filter` | `in_region(λ_min, λ_max, analytic([](λ) { return 1.0; }))` |
-| `exp_decay` | `analytic([](λ) { return pow(10, (300-λ)/14); })` |
-| `PAR` | `in_region(400nm, 700nm, constant(1.0))` |
+| `exp_decay` | `analytic([](λ) { return pow(10, (300e-9-λ)/14e-9); })` |
+| `PAR` | `in_region(400e-9, 700e-9, constant(1.0))` |
 | Others | Literature-specific analytic formulas |

--- a/.github/prompts/phase2-transforms.prompt.md
+++ b/.github/prompts/phase2-transforms.prompt.md
@@ -129,3 +129,7 @@ Temperature parameterization utilities in `src/cross_sections/util/`: `temperatu
 | `exp_decay` | `wrap_analytic([](λ) { return pow(10, (300e-9-λ)/14e-9); })` |
 | `PAR` | `in_region(400e-9, 700e-9, constant(1.0))` |
 | Others | Literature-specific analytic formulas |
+
+### Documentation
+
+Document the `TransformFunc` signature, every factory function, and every combinator with Doxygen `///` comments. For each factory, document the mathematical formula it implements and example usage. For each ported cross-section/quantum yield, reference the Fortran source file.

--- a/.github/prompts/phase2-transforms.prompt.md
+++ b/.github/prompts/phase2-transforms.prompt.md
@@ -8,7 +8,7 @@ The current Fortran codebase has 27 cross-section types, 20 quantum yield types,
 
 ## Step 7: Design the transform type system
 
-Define `TransformFunc` as a callable mapping atmospheric state → 2D output array `[wavelength × height]`:
+Define `TransformFunc` as a callable mapping atmospheric state → 3D output array `[wavelength × height × column]`:
 
 ```cpp
 template<typename ArrayPolicy>
@@ -18,11 +18,13 @@ using TransformFunc = std::function<void(
     const Profile<ArrayPolicy>& temperature,
     const Profile<ArrayPolicy>& pressure,
     const Profile<ArrayPolicy>& air_density,
-    Array2D<typename ArrayPolicy::value_type>& output
+    Array3D<typename ArrayPolicy::value_type>& output  // [wavelength × height × column]
 )>;
 ```
 
-This is the universal signature for cross-sections, quantum yields, and spectral weights.
+This is the universal signature for cross-sections, quantum yields, and spectral weights. The output includes the column dimension because temperature, pressure, and density vary per column, so the computed values differ per column.
+
+Transform implementations should use the **bulk operations API** (`ForEachRow`, `ColumnView`, `Function`) for all per-element computation. For transforms computed from static reference data (loaded via `DataReader`), the reference data is broadcast into the per-column output using `ForEachRow`. Performance-critical transforms (called every timestep) should return pre-compiled `ArrayPolicy::Function` objects.
 
 ## Step 8: Implement composable transform primitives
 

--- a/.github/prompts/phase2-transforms.prompt.md
+++ b/.github/prompts/phase2-transforms.prompt.md
@@ -1,0 +1,100 @@
+# Phase 2: Composable Transform System (Steps 7–12)
+
+See [master plan](plan-tuvXCppSolverRewrite.prompt.md) for overall architecture and key decisions.
+
+## Context
+
+The current Fortran codebase has 27 cross-section types, 20 quantum yield types, and 12 spectral weight types, each implemented as a separate class with a factory pattern. Analysis shows these decompose into ~8 recurring mathematical patterns. The new library replaces this with composable lambda-based transforms configured via a programmatic C++ API (no config files — MUSICA handles configuration).
+
+## Step 7: Design the transform type system
+
+Define `TransformFunc` as a callable mapping atmospheric state → 2D output array `[wavelength × height]`:
+
+```cpp
+template<typename ArrayPolicy>
+using TransformFunc = std::function<void(
+    const Grid<ArrayPolicy>& wavelength_grid,
+    const Grid<ArrayPolicy>& altitude_grid,
+    const Profile<ArrayPolicy>& temperature,
+    const Profile<ArrayPolicy>& pressure,
+    const Profile<ArrayPolicy>& air_density,
+    Array2D<typename ArrayPolicy::value_type>& output
+)>;
+```
+
+This is the universal signature for cross-sections, quantum yields, and spectral weights.
+
+## Step 8: Implement composable transform primitives
+
+Each primitive is a factory function returning a `TransformFunc`:
+
+| Primitive | Math | Replaces (Fortran types) |
+|-----------|------|--------------------------|
+| `from_data(reader, interpolator)` | Tabulated data → model grid interpolation | Base `cross_section_t`, base `quantum_yield_t` |
+| `temperature_interpolation(reader)` | $\sigma(\lambda,T) = \sigma_i + \frac{T-T_i}{T_{i+1}-T_i}(\sigma_{i+1}-\sigma_i)$ | `tint` xs, `tint` qy, `NO2 tint`, `O3 tint` |
+| `polynomial_scaling(coeffs, T_ref)` | $\sigma_0 \cdot P(T-T_{ref}, \lambda)$ | CCl4, acetone, ClONO2, HCFC |
+| `exponential_scaling(coeffs, T_ref)` | $\sigma_0 \cdot \exp(f(T,\lambda))$ | CFC-11, RONO2, N2O5, CHBr3, CH3ONO2 |
+| `linear_correction(slope_data)` | $\sigma_0 + \beta \cdot \Delta T$ | CH2O |
+| `analytic(lambda_expr)` | User-supplied lambda | Rayleigh, nitroxy acetone, nitroxy ethanol |
+| `stern_volmer(phi0, k)` | $\phi = 1/(1/\phi_0 + k \cdot M)$ | CH2O quantum yield |
+| `parameterized(type, params)` | Taylor series, Burkholder, Harwood strategies | `temperature_based` xs |
+
+## Step 9: Implement transform combinators
+
+| Combinator | Semantics |
+|------------|-----------|
+| `in_region(λ_min, λ_max, t)` | Apply `t` only where λ_min ≤ λ ≤ λ_max; zero outside |
+| `compose(base, modifier)` | `output = base * modifier` or `base + modifier` |
+| `piecewise({regions...})` | Different transforms per wavelength region |
+| `clamp(t, min, max)` | Clamp output values |
+| `override_band(name, value, t)` | Replace values in named bands (Lyman-α, Schumann-Runge) |
+| `scale(factor, t)` | Multiply by constant |
+
+## Step 10: Port cross-section algorithms
+
+Express each of the 27 Fortran cross-section types as compositions. Reference files in `src/cross_sections/`:
+
+### Simple cases (direct primitive mapping)
+- `base` → `from_data(reader, conserving_interpolator())`
+- `tint` → `temperature_interpolation(reader)`
+- `CCl4` → `compose(from_data(...), in_region(194nm, 250nm, polynomial_scaling(...)))`
+- `CFC-11` → `compose(from_data(...), exponential_scaling(...))`
+- `CH2O` → `compose(from_data(...), linear_correction(slope_data))`
+- `Rayleigh` → `analytic([](λ) { return 4.02e-28 / pow(λ, p(λ)); })`
+
+### Complex cases (multi-region / custom logic)
+- `O3` → `piecewise({<185nm: data1, 185-195nm: data2, 195-345nm: tint, >345nm: data4})` with refraction correction
+- `H2O2` → blended polynomial via Boltzmann χ — use `analytic()` with custom lambda
+- `acetone` → Horner polynomial in temperature
+
+### Fortran source files to reference
+All in `src/cross_sections/`: `tint.F90`, `temperature_based.F90`, `no2_tint.F90`, `o3_tint.F90`, `rayliegh.F90`, `ccl4.F90`, `cfc-11.F90`, `ch2o.F90`, `h2o2-oh_oh.F90`, `hno3-oh_no2.F90`, `n2o5-no2_no3.F90`, `clono2.F90`, `hobr-oh_br.F90`, `hcfc.F90`, `chbr3.F90`, `chcl3.F90`, `cl2-cl_cl.F90`, `rono2.F90`, `t_butyl_nitrate.F90`, `acetone-ch3co_ch3.F90`, `ch3ono2-ch3o_no2.F90`, `nitroxy_acetone.F90`, `nitroxy_ethanol.F90`, `n2o-n2_o1d.F90`, `oclo.F90`
+
+Temperature parameterization utilities in `src/cross_sections/util/`: `temperature_parameterization.F90`, `temperature_parameterization_taylor_series.F90`, `temperature_parameterization_burkholder.F90`, `temperature_parameterization_harwood.F90`
+
+## Step 11: Port quantum yield algorithms
+
+~20 types in `src/quantum_yields/`. Most map directly to existing primitives:
+
+| Fortran type | Composed transform |
+|--------------|-------------------|
+| `base` | `from_data(...)` or constant value |
+| `tint`, `NO2 tint` | `temperature_interpolation(...)` |
+| `CH2O` | `stern_volmer(phi0, k)` in region 330–360nm |
+| `taylor series` | `analytic(polynomial_lambda)` with clamp(0,1) |
+| `O3→O(1D)` | `analytic(matsumi_formula)` — multi-region Gaussians |
+| `H2SO4 Mills` | `analytic(mean_free_path_formula)` |
+| `acetone` | `analytic(blitz_parameterization)` |
+
+## Step 12: Port spectral weight algorithms
+
+~12 types in `src/spectral_weights/`. Simpler — wavelength-only (no T/P dependence):
+
+| Fortran type | Transform |
+|-------------|-----------|
+| `base` | `from_data(reader, conserving_interpolator())` |
+| `gaussian` | `analytic([](λ, μ) { return exp(-ln2 * 0.04 * (λ-μ)²); })` |
+| `notch_filter` | `in_region(λ_min, λ_max, analytic([](λ) { return 1.0; }))` |
+| `exp_decay` | `analytic([](λ) { return pow(10, (300-λ)/14); })` |
+| `PAR` | `in_region(400nm, 700nm, constant(1.0))` |
+| Others | Literature-specific analytic formulas |

--- a/.github/prompts/phase2-transforms.prompt.md
+++ b/.github/prompts/phase2-transforms.prompt.md
@@ -4,11 +4,15 @@ See [master plan](plan-tuvXCppSolverRewrite.prompt.md) for overall architecture 
 
 ## Context
 
-The current Fortran codebase has 27 cross-section types, 20 quantum yield types, and 12 spectral weight types, each implemented as a separate class with a factory pattern. Analysis shows these decompose into ~8 recurring mathematical patterns. The new library defines an open `TransformFunc` API — any lambda or callable matching the signature is a valid transform. A convenience library of pre-built factory functions covers the common patterns, and combinators allow composing transforms. Users can mix library-provided factories, combinators, and raw user-written lambdas freely. No config files — MUSICA handles configuration.
+The current Fortran codebase has 27 cross-section types, 20 quantum yield types, and 12 spectral weight types, each implemented as a separate class with a factory pattern. Analysis shows these decompose into ~8 recurring mathematical patterns.
+
+**What is a transform?** A transform is a set of per-wavelength, per-height weights `[λ × z × col]` — conceptually a weight matrix that can be *applied* to the radiation field via element-wise multiplication. Cross-sections, quantum yields, and spectral weights are all transforms. The weight values may depend on atmospheric conditions (T, P, density), but those are inputs to the *weight calculation*, not to the application. The pipeline is: **calculate** the transform (produce the weight matrix) → **apply** it to the radiation field (multiply) → **reduce** (sum over wavelengths) to get rates (Phase 3).
+
+The new library defines an open `TransformFunc` API — any lambda or callable matching the signature can *calculate* a transform. A convenience library of pre-built factory functions covers the common weight-calculation patterns, and combinators allow composing weight calculations. Users can mix library-provided factories, combinators, and raw user-written lambdas freely. No config files — MUSICA handles configuration.
 
 ## Step 7: Design the transform type system
 
-Define `TransformFunc` as a callable mapping atmospheric state → 3D output array `[wavelength × height × column]`:
+Define `TransformFunc` as a callable that **calculates** a transform — i.e., fills a weight array `[λ × z × col]` given the current atmospheric state:
 
 ```cpp
 template<typename ArrayPolicy>
@@ -18,30 +22,30 @@ using TransformFunc = std::function<void(
     const Profile<ArrayPolicy>& temperature,
     const Profile<ArrayPolicy>& pressure,
     const Profile<ArrayPolicy>& air_density,
-    Array3D<typename ArrayPolicy::value_type>& output  // [wavelength × height × column]
+    Array3D<typename ArrayPolicy::value_type>& weights  // [λ × z × col] — the calculated transform
 )>;
 ```
 
-**`TransformFunc` is the open, user-facing API.** Any callable matching this signature is a valid transform. Users can write raw lambdas, function objects, or free functions directly — no factory or wrapper is required:
+**`TransformFunc` is the open, user-facing API.** Any callable matching this signature is a valid transform calculator. Users can write raw lambdas, function objects, or free functions directly — no factory or wrapper is required:
 
 ```cpp
-// User-written transform — just a lambda matching the TransformFunc signature:
+// User-written transform — just a lambda that calculates weights:
 TransformFunc<ArrayPolicy> rayleigh_xs = [](const auto& wl_grid, const auto& alt_grid,
-    const auto& temperature, const auto& pressure, const auto& air_density, auto& output) {
-    // Rayleigh scattering formula using ForEachRow, ColumnView, etc.
-    // This IS the transform — no wrapper needed.
+    const auto& temperature, const auto& pressure, const auto& air_density, auto& weights) {
+    // Calculate Rayleigh scattering weights using ForEachRow, ColumnView, etc.
+    // The resulting weights will later be applied to the radiation field.
 };
 ```
 
-The output includes the column dimension because temperature, pressure, and density vary per column, so the computed values differ per column.
+The weights include the column dimension because temperature, pressure, and density vary per column, so the calculated weights differ per column. The weights are later *applied* to the radiation field (element-wise multiplication) in Phase 3 (rate calculation).
 
-Transform implementations should use the **bulk operations API** (`ForEachRow`, `ColumnView`, `Function`) for all per-element computation. For transforms computed from static reference data (loaded via `DataReader`), the reference data is broadcast into the per-column output using `ForEachRow`. Performance-critical transforms (called every timestep) should return pre-compiled `ArrayPolicy::Function` objects.
+Transform implementations should use the **bulk operations API** (`ForEachRow`, `ColumnView`, `Function`) for all per-element computation. For transforms calculated from static reference data (loaded via `DataReader`), the reference data is broadcast into the per-column weights using `ForEachRow`. Performance-critical transforms (calculated every timestep) should return pre-compiled `ArrayPolicy::Function` objects.
 
 ## Step 8: Implement convenience transform library
 
-Provide a library of pre-built factory functions that return `TransformFunc` callables. These are **convenience utilities built on the same public API a user would use** — they capture parameters and return a lambda matching the `TransformFunc` signature. Users can use these off-the-shelf, compose them with combinators (Step 9), or ignore them entirely and write raw lambdas.
+Provide a library of pre-built factory functions that return `TransformFunc` callables — each one calculates a particular kind of weight matrix. These are **convenience utilities built on the same public API a user would use** — they capture parameters and return a lambda that calculates weights matching the `TransformFunc` signature. Users can use these off-the-shelf, compose them with combinators (Step 9), or ignore them entirely and write raw lambdas.
 
-### Factory functions (each returns a `TransformFunc`)
+### Factory functions (each returns a `TransformFunc` that calculates weights)
 
 | Factory function | Math | Useful for |
 |-----------|------|---------------------------|
@@ -59,27 +63,27 @@ Provide a library of pre-built factory functions that return `TransformFunc` cal
 |---------|---------|
 | `wrap_analytic(f)` | Takes a simple `f(λ)→double` or `f(λ,T)→double` and wraps it into the full `TransformFunc` signature, handling grid iteration and column broadcasting internally. Useful for quick one-liner formulas. |
 
-`wrap_analytic` is a convenience for simple formulas — it is **not** the primary way to create custom transforms. For anything beyond a trivial formula, users should write a full `TransformFunc` lambda directly.
+`wrap_analytic` is a convenience for simple formulas — it is **not** the primary way to create custom transforms. For anything beyond a trivial formula, users should write a full `TransformFunc` lambda that calculates the weights directly.
 
 ## Step 9: Implement transform combinators
 
-Combinators are higher-order functions: they take one or more `TransformFunc` values and return a new `TransformFunc`. They work with **any** transform — library-provided factories or user-written lambdas:
+Combinators are higher-order functions: they take one or more `TransformFunc` values and return a new `TransformFunc` that calculates composite weights. They work with **any** transform — library-provided factories or user-written lambdas:
 
 | Combinator | Semantics |
 |------------|-----------|
-| `in_region(λ_min, λ_max, t)` | Apply `t` only where λ_min ≤ λ ≤ λ_max; zero outside |
-| `multiply(a, b)` | Run both transforms, multiply their outputs element-wise |
-| `add(a, b)` | Run both transforms, add their outputs element-wise |
-| `piecewise({regions...})` | Different transforms per wavelength region |
-| `clamp(t, min, max)` | Clamp output values |
-| `override_band(name, value, t)` | Replace values in named bands (Lyman-α, Schumann-Runge) |
-| `scale(factor, t)` | Multiply by constant |
+| `in_region(λ_min, λ_max, t)` | Calculate weights only where λ_min ≤ λ ≤ λ_max; zero outside |
+| `multiply(a, b)` | Calculate both weight sets, multiply element-wise to produce composite weights |
+| `add(a, b)` | Calculate both weight sets, add element-wise to produce composite weights |
+| `piecewise({regions...})` | Calculate different weights per wavelength region |
+| `clamp(t, min, max)` | Clamp calculated weight values |
+| `override_band(name, value, t)` | Replace weight values in named bands (Lyman-α, Schumann-Runge) |
+| `scale(factor, t)` | Multiply calculated weights by constant |
 
-**Why combinators instead of sequential application?** A `TransformFunc` *writes* to the output array — it doesn't modify an existing value. Applying two transforms in sequence would just overwrite the first result with the second. Combinators like `multiply(a, b)` internally run both transforms (one into the output, one into a temporary), then combine the results element-wise.
+**Why combinators instead of sequential calculation?** A `TransformFunc` *writes* to the weight array — it doesn't modify existing values. Calculating two transforms in sequence would just overwrite the first weight set with the second. Combinators like `multiply(a, b)` internally calculate both weight sets (one into the output, one into a temporary), then combine them element-wise to produce a single composite weight matrix.
 
 ## Step 10: Port cross-section algorithms
 
-Express each of the 27 Fortran cross-section types as either a library factory, a composition of factories via combinators, or a user-written `TransformFunc` lambda. Reference files in `src/cross_sections/`:
+Express each of the 27 Fortran cross-section types as a weight calculation: either a library factory, a composition of factories via combinators, or a user-written `TransformFunc` lambda. Reference files in `src/cross_sections/`:
 
 ### Simple cases (direct factory mapping)
 - `base` → `from_data(reader, conserving_interpolator())`

--- a/.github/prompts/phase3-rateEngine.prompt.md
+++ b/.github/prompts/phase3-rateEngine.prompt.md
@@ -26,9 +26,9 @@ API:
 template<typename ArrayPolicy>
 class PhotolysisCalculator {
     void add_reaction(std::string name, TransformFunc<ArrayPolicy> cross_section, TransformFunc<ArrayPolicy> quantum_yield);
-    void calculate(const RadiationField<ArrayPolicy>& field, const AtmosphericState<ArrayPolicy>& state, Array3D<T>& rates);
+    Array3D<typename ArrayPolicy::value_type> calculate(const RadiationField<ArrayPolicy>& field, const AtmosphericState<ArrayPolicy>& state);
     // calculate() internally: (1) calculates each transform's weights from `state`,
-    // (2) applies weights to `field` (element-wise multiply), (3) reduces over wavelengths into `rates`
+    // (2) applies weights to `field` (element-wise multiply), (3) reduces over wavelengths → returns rates [reaction × height × column]
 };
 ```
 

--- a/.github/prompts/phase3-rateEngine.prompt.md
+++ b/.github/prompts/phase3-rateEngine.prompt.md
@@ -16,9 +16,10 @@ where $F$ is actinic flux, $\sigma_i$ is cross-section, $\phi_i$ is quantum yiel
 
 Implementation:
 - Evaluate each reaction's cross-section and quantum yield transforms at the current atmospheric state
-- Compute element-wise product with actinic flux
-- Sum over wavelength dimension (dot product per height layer)
+- Compute element-wise product with actinic flux using `ForEachRow` and column views
+- Sum over wavelength dimension (reduction per height layer per column)
 - Output: 3D array `[reaction × height × column]`
+- Use `ArrayPolicy::Function` to pre-compile the per-timestep rate calculation for optimal vectorization across columns
 
 API:
 ```cpp

--- a/.github/prompts/phase3-rateEngine.prompt.md
+++ b/.github/prompts/phase3-rateEngine.prompt.md
@@ -1,0 +1,55 @@
+# Phase 3: Rate Calculation Engine (Steps 13–15)
+
+See [master plan](plan-tuvXCppSolverRewrite.prompt.md) for overall architecture and key decisions.
+
+## Context
+
+Once the radiation field is solved (Phase 1) and transforms are available (Phase 2), photolysis rates, dose rates, and heating rates are computed by integrating the radiation field against cross-sections, quantum yields, or spectral weights over wavelength. These are all weighted spectral integrals — highly parallelizable across columns and reactions.
+
+## Step 13: Implement photolysis rate calculator
+
+Port `src/photolysis_rates.F90`. The core operation:
+
+$$J_i(z) = \sum_\lambda F(\lambda, z) \cdot \sigma_i(\lambda, z) \cdot \phi_i(\lambda, z) \cdot \Delta\lambda$$
+
+where $F$ is actinic flux, $\sigma_i$ is cross-section, $\phi_i$ is quantum yield, and $\Delta\lambda$ is wavelength bin width.
+
+Implementation:
+- Evaluate each reaction's cross-section and quantum yield transforms at the current atmospheric state
+- Compute element-wise product with actinic flux
+- Sum over wavelength dimension (dot product per height layer)
+- Output: 3D array `[reaction × height × column]`
+
+API:
+```cpp
+template<typename ArrayPolicy>
+class PhotolysisCalculator {
+    void add_reaction(std::string name, TransformFunc<ArrayPolicy> cross_section, TransformFunc<ArrayPolicy> quantum_yield);
+    void calculate(const RadiationField<ArrayPolicy>& field, const AtmosphericState<ArrayPolicy>& state, Array3D<T>& rates);
+};
+```
+
+Parallelization: reactions are independent — can be computed in parallel across reactions and columns.
+
+### Fortran reference
+- `src/photolysis_rates.F90` — `photolysis_rates_t` class, `calculate()` method uses `dot_product(actinicFlux, cross_section * quantum_yield)` per height layer
+
+## Step 14: Implement dose rate calculator
+
+Port `src/dose_rates.F90`. Similar structure:
+
+$$D(z) = \sum_\lambda I_{irrad}(\lambda, z) \cdot W(\lambda)$$
+
+where $I_{irrad}$ combines direct, upwelling, and downwelling spectral irradiance (converted to $W \cdot m^{-2}$), and $W(\lambda)$ is a spectral weighting function.
+
+Implementation uses `matmul(irradiance_matrix, spectral_weight_vector)` per height layer.
+
+### Fortran reference
+- `src/dose_rates.F90` — `dose_rates_t` class
+
+## Step 15: Implement heating rate calculator
+
+Port `src/heating_rates.F90`.
+
+### Fortran reference
+- `src/heating_rates.F90` — `heating_rates_t` class

--- a/.github/prompts/phase3-rateEngine.prompt.md
+++ b/.github/prompts/phase3-rateEngine.prompt.md
@@ -56,3 +56,7 @@ Port `src/heating_rates.F90`.
 
 ### Fortran reference
 - `src/heating_rates.F90` — `heating_rates_t` class
+
+### Documentation
+
+Document `PhotolysisCalculator`, `DoseRateCalculator`, and `HeatingRateCalculator` with Doxygen `///` comments. Explain the calculate/apply/reduce pipeline in the class-level doc. Reference the Fortran source.

--- a/.github/prompts/phase3-rateEngine.prompt.md
+++ b/.github/prompts/phase3-rateEngine.prompt.md
@@ -4,7 +4,7 @@ See [master plan](plan-tuvXCppSolverRewrite.prompt.md) for overall architecture 
 
 ## Context
 
-Once the radiation field is solved (Phase 1) and transforms are available (Phase 2), photolysis rates, dose rates, and heating rates are computed by integrating the radiation field against cross-sections, quantum yields, or spectral weights over wavelength. These are all weighted spectral integrals — highly parallelizable across columns and reactions.
+Once the radiation field is solved (Phase 1) and transforms are defined (Phase 2), rates are computed by a three-step pipeline: (1) **calculate** each transform (cross-section, quantum yield, or spectral weight) to produce weight matrices `[λ × z × col]`, (2) **apply** the weights to the radiation field via element-wise multiplication, (3) **reduce** by summing over wavelengths to produce rates `[z × col]`. These are all weighted spectral integrals — highly parallelizable across columns and reactions.
 
 ## Step 13: Implement photolysis rate calculator
 
@@ -15,9 +15,9 @@ $$J_i(z) = \sum_\lambda F(\lambda, z) \cdot \sigma_i(\lambda, z) \cdot \phi_i(\l
 where $F$ is actinic flux, $\sigma_i$ is cross-section, $\phi_i$ is quantum yield, and $\Delta\lambda$ is wavelength bin width.
 
 Implementation:
-- Evaluate each reaction's cross-section and quantum yield transforms at the current atmospheric state
-- Compute element-wise product with actinic flux using `ForEachRow` and column views
-- Sum over wavelength dimension (reduction per height layer per column)
+- **Calculate**: evaluate each reaction's cross-section and quantum yield transforms at the current atmospheric state to produce weight matrices
+- **Apply**: compute element-wise product of actinic flux × σ weights × φ weights × Δλ using `ForEachRow` and column views
+- **Reduce**: sum over wavelength dimension (reduction per height layer per column)
 - Output: 3D array `[reaction × height × column]`
 - Use `ArrayPolicy::Function` to pre-compile the per-timestep rate calculation for optimal vectorization across columns
 
@@ -27,6 +27,8 @@ template<typename ArrayPolicy>
 class PhotolysisCalculator {
     void add_reaction(std::string name, TransformFunc<ArrayPolicy> cross_section, TransformFunc<ArrayPolicy> quantum_yield);
     void calculate(const RadiationField<ArrayPolicy>& field, const AtmosphericState<ArrayPolicy>& state, Array3D<T>& rates);
+    // calculate() internally: (1) calculates each transform's weights from `state`,
+    // (2) applies weights to `field` (element-wise multiply), (3) reduces over wavelengths into `rates`
 };
 ```
 

--- a/.github/prompts/phase4-radiatorState.prompt.md
+++ b/.github/prompts/phase4-radiatorState.prompt.md
@@ -26,10 +26,10 @@ Host models provide radiator data directly via the C++ API — no config-file-ba
 
 ## Step 17: Implement Lyman-Alpha and Schumann-Runge band parameterization
 
-Port `src/la_sr_bands.F90`. This handles special UV absorption bands of O₂ (121.4–175.4 nm) that require separate treatment:
+Port `src/la_sr_bands.F90`. This handles special UV absorption bands of O₂ (121.4e-9–175.4e-9 m) that require separate treatment:
 
-- Lyman-Alpha band: strong O₂ absorption line at 121.6 nm
-- Schumann-Runge bands: structured O₂ absorption between 175–205 nm
+- Lyman-Alpha band: strong O₂ absorption line at 121.6e-9 m
+- Schumann-Runge bands: structured O₂ absorption between 175e-9–205e-9 m
 - These bands use lookup tables and parameterized transmission functions rather than the standard column-by-column solver
 
 ### Fortran reference

--- a/.github/prompts/phase4-radiatorState.prompt.md
+++ b/.github/prompts/phase4-radiatorState.prompt.md
@@ -1,0 +1,52 @@
+# Phase 4: Radiator and Atmospheric State (Steps 16–18)
+
+See [master plan](plan-tuvXCppSolverRewrite.prompt.md) for overall architecture and key decisions.
+
+## Context
+
+Before the solver can compute the radiation field, the optical properties of the atmosphere must be assembled. Radiators contribute optical depth, single-scattering albedo, and asymmetry parameter arrays. The Lyman-Alpha and Schumann-Runge bands require special parameterization. Interpolation utilities support data loading.
+
+## Step 16: Implement radiator accumulation
+
+Port the radiator system from `src/radiative_transfer/radiators/`.
+
+In the new API, radiators are objects providing optical depth, single-scattering albedo, and asymmetry parameter arrays per wavelength per layer per column. The `RadiatorState::Accumulate()` method (currently a placeholder in the C++ code) sums contributions from multiple radiators using the correct weighting:
+
+- Optical depth: additive ($\tau_{total} = \sum \tau_i$)
+- Single-scattering albedo: weighted by optical depth ($\omega_{total} = \sum \omega_i \tau_i / \tau_{total}$)
+- Asymmetry parameter: weighted by SSA × optical depth ($g_{total} = \sum g_i \omega_i \tau_i / (\omega_{total} \tau_{total})$)
+
+Host models provide radiator data directly via the C++ API — no config-file-based radiator construction.
+
+### Fortran reference
+- `src/radiative_transfer/radiators/aerosol.F90`
+- `src/radiative_transfer/radiators/from_host.F90`
+- `src/radiative_transfer/radiators/from_netcdf_file.F90`
+- `src/radiative_transfer/radiative_transfer.F90` — orchestrator that iterates over radiators
+
+## Step 17: Implement Lyman-Alpha and Schumann-Runge band parameterization
+
+Port `src/la_sr_bands.F90`. This handles special UV absorption bands of O₂ (121.4–175.4 nm) that require separate treatment:
+
+- Lyman-Alpha band: strong O₂ absorption line at 121.6 nm
+- Schumann-Runge bands: structured O₂ absorption between 175–205 nm
+- These bands use lookup tables and parameterized transmission functions rather than the standard column-by-column solver
+
+### Fortran reference
+- `src/la_sr_bands.F90` — `la_sr_bands_t` class with LUT-based calculations
+
+## Step 18: Implement interpolation utilities
+
+Port the 4 interpolator types from `src/interpolate.F90`:
+
+| Interpolator | Use case | Method |
+|-------------|----------|--------|
+| `linear` | Point-to-point (temperature profiles) | Linear interpolation |
+| `conserving` | Cross-sections, quantum yields (default) | Area-preserving: trapezoidal area over source bins ÷ target bin width |
+| `fractional_source` | Bin-to-bin relative to source width | For extraterrestrial flux |
+| `fractional_target` | Bin-to-bin relative to target width | For bin-mapped data |
+
+The conserving interpolator is the most important — it ensures spectral quantities are correctly mapped between wavelength grids while preserving integrated values. Supports `fold_in` for handling data that extends beyond the model grid.
+
+### Fortran reference
+- `src/interpolate.F90` — `interpolator_linear_t`, `interpolator_conserving_t`, `interpolator_fractional_source_t`, `interpolator_fractional_target_t`

--- a/.github/prompts/phase4-radiatorState.prompt.md
+++ b/.github/prompts/phase4-radiatorState.prompt.md
@@ -50,3 +50,7 @@ The conserving interpolator is the most important — it ensures spectral quanti
 
 ### Fortran reference
 - `src/interpolate.F90` — `interpolator_linear_t`, `interpolator_conserving_t`, `interpolator_fractional_source_t`, `interpolator_fractional_target_t`
+
+### Documentation
+
+Document `RadiatorState::Accumulate()`, the Lyman-α/Schumann-Runge parameterization, and each interpolator with Doxygen `///` comments. For `Accumulate()`, document the weighting formulas (τ additive, SSA/g weighted by τ). Reference Fortran source files.

--- a/.github/prompts/phase5-dataReaders.prompt.md
+++ b/.github/prompts/phase5-dataReaders.prompt.md
@@ -50,3 +50,7 @@ The pluggable interface allows adding CSV, HDF5, binary, or in-memory readers wi
 - `src/netcdf.F90` — NetCDF reading utilities used by cross-section and quantum yield constructors
 - `data/cross_sections/` — 145+ `.nc` files
 - `data/quantum_yields/` — 14 `.nc` files
+
+### Documentation
+
+Document the `DataReader` interface and `NetCDFReader` implementation with Doxygen `///` comments. Document the expected file format, the SI-unit requirement, and how users implement custom readers.

--- a/.github/prompts/phase5-dataReaders.prompt.md
+++ b/.github/prompts/phase5-dataReaders.prompt.md
@@ -19,12 +19,14 @@ public:
     virtual Array2D<double> read_parameters(const std::string& variable_prefix) = 0;
 
     /// Read the wavelength grid [m]
-    virtual std::vector<double> read_wavelengths() = 0;
+    virtual Array1D<double> read_wavelengths() = 0;
 
     /// Read temperature grid (optional — only for T-dependent data)
-    virtual std::vector<double> read_temperatures() = 0;
+    virtual Array1D<double> read_temperatures() = 0;
 };
 ```
+
+**Note**: The `DataReader` returns `Array1D` (not `std::vector`) so that returned data can be directly used with policy-backed types (`Grid`, `Profile`, etc.) without copies. When the solver runs on GPU, these arrays may need to reside in device memory — `std::vector` cannot support this.
 
 ### NetCDF-C reader implementation
 

--- a/.github/prompts/phase5-dataReaders.prompt.md
+++ b/.github/prompts/phase5-dataReaders.prompt.md
@@ -1,0 +1,50 @@
+# Phase 5: Data Reader Abstraction (Step 19)
+
+See [master plan](plan-tuvXCppSolverRewrite.prompt.md) for overall architecture and key decisions.
+
+## Context
+
+The current Fortran code reads ~160 NetCDF files for cross-section and quantum yield parameter data at initialization time. The new library needs a pluggable data reader interface with a default NetCDF-C implementation (no Fortran dependency).
+
+## Step 19: Define pluggable data reader interface
+
+### Interface design
+
+```cpp
+class DataReader {
+public:
+    virtual ~DataReader() = default;
+
+    /// Read parameter data as a 2D array [wavelength × parameter_index]
+    virtual Array2D<double> read_parameters(const std::string& variable_prefix) = 0;
+
+    /// Read the wavelength grid [nm or m depending on convention]
+    virtual std::vector<double> read_wavelengths() = 0;
+
+    /// Read temperature grid (optional — only for T-dependent data)
+    virtual std::vector<double> read_temperatures() = 0;
+};
+```
+
+### NetCDF-C reader implementation
+
+Implement `NetCDFReader : DataReader` using the NetCDF-C library (`libnetcdf`):
+- Opens `.nc` files and reads `wavelength`, `temperature`, `{prefix}_parameters` variables
+- The existing ~160 NetCDF files in `data/cross_sections/` and `data/quantum_yields/` use a consistent naming convention with variable prefixes `cross_section_`, `quantum_yield_`, `temperature_`
+- Unit conversion: data files use nm for wavelength and K for temperature; convert to SI (meters) at read time
+
+### NetCDF variable structure (existing files)
+- `wavelength` — 1D array of wavelengths [nm]
+- `temperature` — 1D array of temperatures [K] (optional)
+- `{prefix}_parameters` — 2D array `[wavelength × parameter_type]`
+
+### Future readers
+The pluggable interface allows adding CSV, HDF5, binary, or in-memory readers without changing transform code. This is particularly useful for:
+- Testing (in-memory data readers)
+- Alternative data formats
+- Embedded/compiled-in data for deployment without data files
+
+### Fortran reference
+- `src/netcdf.F90` — NetCDF reading utilities used by cross-section and quantum yield constructors
+- `data/cross_sections/` — 145+ `.nc` files
+- `data/quantum_yields/` — 14 `.nc` files

--- a/.github/prompts/phase5-dataReaders.prompt.md
+++ b/.github/prompts/phase5-dataReaders.prompt.md
@@ -18,7 +18,7 @@ public:
     /// Read parameter data as a 2D array [wavelength × parameter_index]
     virtual Array2D<double> read_parameters(const std::string& variable_prefix) = 0;
 
-    /// Read the wavelength grid [nm or m depending on convention]
+    /// Read the wavelength grid [m]
     virtual std::vector<double> read_wavelengths() = 0;
 
     /// Read temperature grid (optional — only for T-dependent data)
@@ -31,10 +31,10 @@ public:
 Implement `NetCDFReader : DataReader` using the NetCDF-C library (`libnetcdf`):
 - Opens `.nc` files and reads `wavelength`, `temperature`, `{prefix}_parameters` variables
 - The existing ~160 NetCDF files in `data/cross_sections/` and `data/quantum_yields/` use a consistent naming convention with variable prefixes `cross_section_`, `quantum_yield_`, `temperature_`
-- Unit conversion: data files use nm for wavelength and K for temperature; convert to SI (meters) at read time
+- No unit conversions: all data files must provide wavelengths in meters (m) and temperatures in Kelvin (K). If legacy data files use nm, they must be converted to SI units before use by TUV-x
 
 ### NetCDF variable structure (existing files)
-- `wavelength` — 1D array of wavelengths [nm]
+- `wavelength` — 1D array of wavelengths [m]
 - `temperature` — 1D array of temperatures [K] (optional)
 - `{prefix}_parameters` — 2D array `[wavelength × parameter_type]`
 

--- a/.github/prompts/phase6-publicAPI.prompt.md
+++ b/.github/prompts/phase6-publicAPI.prompt.md
@@ -59,9 +59,10 @@ public:
 
 ### Design principles
 - Template on `ArrayPolicy` — same API for CPU and GPU
-- Batch-oriented: always operates on collections of columns
+- Batch-oriented: always operates on collections of columns via `ForEachRow`/`Function` bulk operations
 - No internal state beyond registered reactions — thread-safe after setup
 - All units in SI
+- **MICM-consistent API conventions**: square-bracket element access (`array[i][j]`), `ForEachRow`/`ColumnView`/`Function` factory, `NumRows()`/`NumColumns()` queries — consistent with MICM's `Matrix`/`VectorMatrix` types since both are MUSICA components
 
 ### Fortran reference
 - `src/core.F90` — `core_t` class: the current top-level API with `run()`, `get_grid()`, `get_profile()`, `get_photolysis_cross_section()`, etc.

--- a/.github/prompts/phase6-publicAPI.prompt.md
+++ b/.github/prompts/phase6-publicAPI.prompt.md
@@ -16,14 +16,14 @@ namespace tuvx {
 /// Atmospheric column state for a batch of columns
 template<typename ArrayPolicy>
 struct AtmosphericState {
-    Grid<ArrayPolicy> altitude_grid;        // per-column vertical grid [m]
-    Grid<ArrayPolicy> wavelength_grid;      // shared wavelength grid [m]
-    Profile<ArrayPolicy> temperature;       // temperature profile [K]
-    Profile<ArrayPolicy> pressure;          // pressure profile [Pa]
-    Profile<ArrayPolicy> air_density;       // air number density [molec/m³]
-    std::vector<double> solar_zenith_angles; // per-column [rad]
-    std::vector<double> earth_sun_distances; // per-column [AU]
-    double surface_albedo;
+    Grid<ArrayPolicy> altitude_grid;           // per-column vertical grid [m]
+    Grid<ArrayPolicy> wavelength_grid;         // shared wavelength grid [m]
+    Profile<ArrayPolicy> temperature;          // temperature profile [K]
+    Profile<ArrayPolicy> pressure;             // pressure profile [Pa]
+    Profile<ArrayPolicy> air_density;          // air number density [molec/m³]
+    Array1D<typename ArrayPolicy::value_type> solar_zenith_angles;   // per-column [rad]
+    Array1D<typename ArrayPolicy::value_type> earth_sun_distances;   // per-column [AU]
+    typename ArrayPolicy::value_type surface_albedo;
 };
 
 /// Solver for radiative transfer

--- a/.github/prompts/phase6-publicAPI.prompt.md
+++ b/.github/prompts/phase6-publicAPI.prompt.md
@@ -93,7 +93,10 @@ This enables:
 - MUSICA's Fortran interface via `iso_c_binding`
 - Python bindings via ctypes (fallback) or direct PyBind11 wrapping of C++ API
 - JavaScript/WASM compilation
-- Julia `ccall`
 
 ### Reference
 - `test/regression/solvers/delta_eddington.hpp` — existing C-interop struct pattern (`SolverInput`, `SolverOutput`)
+
+### Documentation
+
+The public API is the primary user-facing surface — document thoroughly. Every class, method, and C function gets Doxygen `///` comments. Include a brief usage example in the `Solver` class-level doc. The C API wrapper functions should document ownership semantics (who frees what). Update the README with a complete build-and-use example.

--- a/.github/prompts/phase6-publicAPI.prompt.md
+++ b/.github/prompts/phase6-publicAPI.prompt.md
@@ -1,0 +1,98 @@
+# Phase 6: Public API (Steps 20–21)
+
+See [master plan](plan-tuvXCppSolverRewrite.prompt.md) for overall architecture and key decisions.
+
+## Context
+
+The public API replaces the Fortran `core_t` class. It is purely programmatic — no config files. Configuration mapping (YAML/JSON → API calls) is MUSICA's responsibility. The API must support both C++ direct use and FFI consumption via a C wrapper.
+
+## Step 20: Define the top-level solver API
+
+### C++ API design
+
+```cpp
+namespace tuvx {
+
+/// Atmospheric column state for a batch of columns
+template<typename ArrayPolicy>
+struct AtmosphericState {
+    Grid<ArrayPolicy> altitude_grid;        // per-column vertical grid [m]
+    Grid<ArrayPolicy> wavelength_grid;      // shared wavelength grid [m]
+    Profile<ArrayPolicy> temperature;       // temperature profile [K]
+    Profile<ArrayPolicy> pressure;          // pressure profile [Pa]
+    Profile<ArrayPolicy> air_density;       // air number density [molec/m³]
+    std::vector<double> solar_zenith_angles; // per-column [rad]
+    std::vector<double> earth_sun_distances; // per-column [AU]
+    double surface_albedo;
+};
+
+/// Solver for radiative transfer
+template<typename ArrayPolicy>
+class Solver {
+public:
+    void solve(
+        const AtmosphericState<ArrayPolicy>& state,
+        const RadiatorState<ArrayPolicy>& radiator_state,
+        RadiationField<ArrayPolicy>& radiation_field
+    );
+};
+
+/// Full pipeline: radiation field → photolysis/dose/heating rates
+template<typename ArrayPolicy>
+class PhotolysisCalculator {
+public:
+    void add_reaction(
+        std::string name,
+        TransformFunc<ArrayPolicy> cross_section,
+        TransformFunc<ArrayPolicy> quantum_yield,
+        double scaling_factor = 1.0
+    );
+    void calculate(
+        const RadiationField<ArrayPolicy>& field,
+        const AtmosphericState<ArrayPolicy>& state,
+        Array3D<typename ArrayPolicy::value_type>& rates  // [reaction × height × column]
+    );
+};
+
+} // namespace tuvx
+```
+
+### Design principles
+- Template on `ArrayPolicy` — same API for CPU and GPU
+- Batch-oriented: always operates on collections of columns
+- No internal state beyond registered reactions — thread-safe after setup
+- All units in SI
+
+### Fortran reference
+- `src/core.F90` — `core_t` class: the current top-level API with `run()`, `get_grid()`, `get_profile()`, `get_photolysis_cross_section()`, etc.
+
+## Step 21: C API wrapper
+
+Provide `extern "C"` functions for FFI consumption:
+
+```c
+// Opaque handle types
+typedef struct tuvx_solver* tuvx_solver_t;
+typedef struct tuvx_calculator* tuvx_calculator_t;
+typedef struct tuvx_radiation_field* tuvx_radiation_field_t;
+
+// Lifecycle
+tuvx_solver_t tuvx_create_solver();
+void tuvx_destroy_solver(tuvx_solver_t solver);
+
+// Solve
+void tuvx_solve(tuvx_solver_t solver, /* flat array inputs */);
+
+// Results
+void tuvx_get_radiation_field(tuvx_solver_t solver, tuvx_radiation_field_t field);
+void tuvx_get_photolysis_rates(tuvx_calculator_t calc, double* rates, int* dims);
+```
+
+This enables:
+- MUSICA's Fortran interface via `iso_c_binding`
+- Python bindings via ctypes (fallback) or direct PyBind11 wrapping of C++ API
+- JavaScript/WASM compilation
+- Julia `ccall`
+
+### Reference
+- `test/regression/solvers/delta_eddington.hpp` — existing C-interop struct pattern (`SolverInput`, `SolverOutput`)

--- a/.github/prompts/phase6-publicAPI.prompt.md
+++ b/.github/prompts/phase6-publicAPI.prompt.md
@@ -13,26 +13,35 @@ The public API replaces the Fortran `core_t` class. It is purely programmatic �
 ```cpp
 namespace tuvx {
 
-/// Atmospheric column state for a batch of columns
+/// Atmospheric column state for a batch of columns.
+/// This is the single state object passed to TransformFunc — it carries everything
+/// a transform might need. Add fields here as needed (e.g., constituent concentrations
+/// for quenching quantum yields) without breaking the TransformFunc signature.
 template<typename ArrayPolicy>
 struct AtmosphericState {
-    Grid<ArrayPolicy> altitude_grid;           // per-column vertical grid [m]
+    Grid<ArrayPolicy> height;                  // per-column vertical grid [m]
     Grid<ArrayPolicy> wavelength_grid;         // shared wavelength grid [m]
     Profile<ArrayPolicy> temperature;          // temperature profile [K]
     Profile<ArrayPolicy> pressure;             // pressure profile [Pa]
-    Profile<ArrayPolicy> air_density;          // air number density [molec/m³]
-    Array1D<typename ArrayPolicy::value_type> solar_zenith_angles;   // per-column [rad]
-    Array1D<typename ArrayPolicy::value_type> earth_sun_distances;   // per-column [AU]
-    typename ArrayPolicy::value_type surface_albedo;
+    Profile<ArrayPolicy> air_density;          // air number density [mol/m³]
+    Profile<ArrayPolicy> surface_albedo;       // per-column, potentially per-wavelength [dimensionless]
+    Array1D<typename ArrayPolicy::value_type> solar_zenith_angle;    // per-column [rad]
+    Array1D<typename ArrayPolicy::value_type> earth_sun_distance;    // per-column [AU]
+    // Extensible: add constituent concentrations, surface properties, etc. as needed
 };
 
-/// Solver for radiative transfer
+/// Solver for radiative transfer.
+/// Radiators are configured at construction (via builder) and owned by the solver.
 template<typename ArrayPolicy>
 class Solver {
 public:
-    void solve(
+    /// Create a properly-sized atmospheric state container
+    AtmosphericState<ArrayPolicy> GetState(int num_columns);
+    /// Create a properly-sized radiation field container
+    RadiationField<ArrayPolicy> GetRadiationField(int num_columns);
+    /// Solve the radiative transfer equation. Returns convergence/diagnostic info.
+    SolveResult solve(
         const AtmosphericState<ArrayPolicy>& state,
-        const RadiatorState<ArrayPolicy>& radiator_state,
         RadiationField<ArrayPolicy>& radiation_field
     );
 };
@@ -47,11 +56,11 @@ public:
         TransformFunc<ArrayPolicy> quantum_yield,
         double scaling_factor = 1.0
     );
-    void calculate(
+    /// Calculate rates: (1) calculate transforms, (2) apply to field, (3) reduce over wavelengths
+    Array3D<typename ArrayPolicy::value_type> calculate(
         const RadiationField<ArrayPolicy>& field,
-        const AtmosphericState<ArrayPolicy>& state,
-        Array3D<typename ArrayPolicy::value_type>& rates  // [reaction × height × column]
-    );
+        const AtmosphericState<ArrayPolicy>& state
+    );  // returns [reaction × height × column]
 };
 
 } // namespace tuvx

--- a/.github/prompts/phase7-discreteOrdinate.prompt.md
+++ b/.github/prompts/phase7-discreteOrdinate.prompt.md
@@ -26,3 +26,7 @@ Port `src/radiative_transfer/solvers/discrete_ordinant_util.F90` — the `PSNDO`
 - `src/radiative_transfer/solvers/discrete_ordinant.F90` — wrapper (~282 lines)
 - `src/radiative_transfer/solvers/discrete_ordinant_util.F90` — full DISORT implementation (~3,700 lines, `PSNDO` subroutine)
 - `src/radiative_transfer/solver_factory.F90` — dispatches on `"discrete ordinate"` type string
+
+### Documentation
+
+Document the DISORT solver's public interface and key internal steps with Doxygen `///` comments. Reference the Fortran `PSNDO` subroutine and relevant literature (Stamnes et al., 1988). Note how it differs from Delta Eddington in stream count and accuracy.

--- a/.github/prompts/phase7-discreteOrdinate.prompt.md
+++ b/.github/prompts/phase7-discreteOrdinate.prompt.md
@@ -1,0 +1,28 @@
+# Phase 7: Discrete Ordinate Solver (Step 22)
+
+See [master plan](plan-tuvXCppSolverRewrite.prompt.md) for overall architecture and key decisions.
+
+## Context
+
+The Discrete Ordinate solver (DISORT) is a multi-stream radiative transfer method supporting 2–32 even streams. It is more accurate than the two-stream Delta Eddington but computationally heavier. The Fortran implementation is ~3,700 lines. This phase should only begin after the Delta Eddington solver and full pipeline are working end-to-end.
+
+## Step 22: Port the DISORT solver
+
+Port `src/radiative_transfer/solvers/discrete_ordinant_util.F90` — the `PSNDO` subroutine and supporting functions.
+
+### Key characteristics
+- Multi-stream method: supports 2, 4, 8, 16, 32 streams (even numbers)
+- Much more computationally intensive than Delta Eddington — stronger candidate for GPU acceleration
+- Well-known community code with extensive literature
+- The Fortran wrapper is in `src/radiative_transfer/solvers/discrete_ordinant.F90` (~282 lines)
+
+### Implementation approach
+- Same `ArrayPolicy` template system as Delta Eddington
+- Same `Solver` API — the solver type is selected at construction, not runtime
+- GPU acceleration will have the most impact here due to the computational intensity
+- Consider batching strategies: multiple columns can share the angular quadrature setup
+
+### Fortran reference
+- `src/radiative_transfer/solvers/discrete_ordinant.F90` — wrapper (~282 lines)
+- `src/radiative_transfer/solvers/discrete_ordinant_util.F90` — full DISORT implementation (~3,700 lines, `PSNDO` subroutine)
+- `src/radiative_transfer/solver_factory.F90` — dispatches on `"discrete ordinate"` type string

--- a/.github/prompts/phase8-musicaIntegration.prompt.md
+++ b/.github/prompts/phase8-musicaIntegration.prompt.md
@@ -4,7 +4,7 @@ See [master plan](plan-tuvXCppSolverRewrite.prompt.md) for overall architecture 
 
 ## Context
 
-MUSICA (Multi-Scale Infrastructure for Chemistry and Aerosols) is the parent library that combines TUV-x with other chemistry tools (MICM, CARMA, MechanismConfiguration) and exposes them through Python, JavaScript, Julia, and Fortran interfaces. The new tuv-x C++ library must integrate seamlessly.
+MUSICA (Multi-Scale Infrastructure for Chemistry and Aerosols) is the parent library that combines TUV-x with other chemistry tools (MICM, CARMA, MechanismConfiguration) and exposes them through Python, JavaScript, and Fortran interfaces. The new tuv-x C++ library must integrate seamlessly.
 
 ### MICM API Consistency
 
@@ -33,7 +33,7 @@ MUSICA uses FetchContent to pull tuv-x. Update the dependency variables:
 # In MUSICA's cmake/dependencies.cmake
 FetchContent_Declare(
     tuvx
-    GIT_REPOSITORY ${TUVX_GIT_REPOSITORY}  # point to new repo
+    GIT_REPOSITORY ${TUVX_GIT_REPOSITORY}  # same repo, point to cpp-rewrite branch (then main once merged)
     GIT_TAG ${TUVX_GIT_TAG}
 )
 ```
@@ -64,23 +64,21 @@ This maps the existing config types (`"tint"`, `"O3"`, `"temperature based"`, et
 
 - **Python** (PyBind11): Wrap the C++ `Solver` and `PhotolysisCalculator` classes. Transforms can be specified as Python callables or by name (MUSICA maps names to C++ lambdas).
 - **JavaScript** (WASM): Compile C++ solver to WebAssembly via Emscripten. Only CPU path.
-- **Julia**: `ccall` into the C API wrapper.
 - **Fortran**: `iso_c_binding` into the C API wrapper (for legacy model integration).
 
 ### Migration path
 
-1. New tuv-x library reaches feature parity with Fortran for Delta Eddington solver
-2. MUSICA adds the new library as an alternative dependency alongside the old one
+1. C++ implementation reaches feature parity with Fortran for Delta Eddington solver
+2. MUSICA points `TUVX_GIT_TAG` at the `cpp-rewrite` branch for testing
 3. Regression tests verify identical output
-4. MUSICA switches default to new library
-5. Old Fortran tuv-x repo archived (kept for reference)
+4. `cpp-rewrite` branch merges to `main`, replacing the Fortran code
+5. Fortran code preserved in git history for reference
 
 ### Key MUSICA references
 - [MUSICA repo](https://github.com/NCAR/musica) — `cmake/dependencies.cmake` for FetchContent setup
 - `include/musica/` — C++ API headers
 - `python/` — PyBind11 bindings
 - `javascript/` — WASM/Emscripten build
-- `julia/` — Julia wrapper
 - `fortran/` — Fortran interface via `iso_c_binding`
 
 ### Existing TUV-x integration in MUSICA

--- a/.github/prompts/phase8-musicaIntegration.prompt.md
+++ b/.github/prompts/phase8-musicaIntegration.prompt.md
@@ -6,6 +6,23 @@ See [master plan](plan-tuvXCppSolverRewrite.prompt.md) for overall architecture 
 
 MUSICA (Multi-Scale Infrastructure for Chemistry and Aerosols) is the parent library that combines TUV-x with other chemistry tools (MICM, CARMA, MechanismConfiguration) and exposes them through Python, JavaScript, Julia, and Fortran interfaces. The new tuv-x C++ library must integrate seamlessly.
 
+### MICM API Consistency
+
+TUV-x and MICM are both MUSICA components and should present a consistent interface to users working across both libraries. The following conventions are shared:
+
+| Convention | MICM | TUV-x | Notes |
+|-----------|------|-------|-------|
+| Element access | `matrix[row][col]` | `array[i][j]`, `array[i][j][k]` | Square-bracket syntax via proxy objects |
+| Bulk iteration | `matrix.ForEachRow(lambda, views...)` | `array.ForEachRow(lambda, views...)` | Policy controls vectorization |
+| Column access | `GetColumnView(col)`, `GetConstColumnView(col)` | Same | Read-only and mutable views |
+| Temporaries | `GetRowVariable()` | Same | Per-row intermediate storage |
+| Function factory | `MatrixPolicy<T>::Function(lambda, args...)` | `ArrayType<T>::Function(lambda, args...)` | Policy-compiled reusable operations |
+| Dimension queries | `NumRows()`, `NumColumns()` | `NumRows()`, `NumColumns()` | Matching names |
+| Template policy | `template<class> class MatrixPolicy` | `typename ArrayPolicy` | Same pattern, different naming (TUV-x uses existing convention) |
+| `std::vector` in APIs | Used alongside `MatrixPolicy` | **Replaced by `Array1D`** | TUV-x is stricter — no `std::vector` in policy-adjacent APIs; MICM may adopt this later |
+
+Diverge from MICM conventions **only** when TUV-x requirements demand it.
+
 ## Step 23: Update MUSICA to consume the new library
 
 ### CMake integration

--- a/.github/prompts/phase8-musicaIntegration.prompt.md
+++ b/.github/prompts/phase8-musicaIntegration.prompt.md
@@ -52,13 +52,13 @@ TransformFunc<HostArrayPolicy> build_cross_section(const YAML::Node& config) {
         auto reader = NetCDFReader(config["netcdf files"][0]["file path"]);
         return temperature_interpolation(reader);
     } else if (type == "CCl4+hv->Products") {
-        // ... compose primitives per config
+        // ... build transform using multiply/add/piecewise per config
     }
     // etc.
 }
 ```
 
-This maps the existing config types (`"tint"`, `"O3"`, `"temperature based"`, etc.) to composed transforms.
+This maps the existing config types (`"tint"`, `"O3"`, `"temperature based"`, etc.) to transforms built with factories and combinators.
 
 ### Language bindings
 

--- a/.github/prompts/phase8-musicaIntegration.prompt.md
+++ b/.github/prompts/phase8-musicaIntegration.prompt.md
@@ -1,0 +1,72 @@
+# Phase 8: MUSICA Integration (Step 23)
+
+See [master plan](plan-tuvXCppSolverRewrite.prompt.md) for overall architecture and key decisions.
+
+## Context
+
+MUSICA (Multi-Scale Infrastructure for Chemistry and Aerosols) is the parent library that combines TUV-x with other chemistry tools (MICM, CARMA, MechanismConfiguration) and exposes them through Python, JavaScript, Julia, and Fortran interfaces. The new tuv-x C++ library must integrate seamlessly.
+
+## Step 23: Update MUSICA to consume the new library
+
+### CMake integration
+
+MUSICA uses FetchContent to pull tuv-x. Update the dependency variables:
+
+```cmake
+# In MUSICA's cmake/dependencies.cmake
+FetchContent_Declare(
+    tuvx
+    GIT_REPOSITORY ${TUVX_GIT_REPOSITORY}  # point to new repo
+    GIT_TAG ${TUVX_GIT_TAG}
+)
+```
+
+The new library should export a `musica::tuvx` CMake target (matching current convention).
+
+### Configuration layer (built in MUSICA, not in tuv-x)
+
+MUSICA builds the bridge between YAML/JSON configuration and the pure C++ API:
+
+```cpp
+// In MUSICA's code, not in tuv-x
+TransformFunc<HostArrayPolicy> build_cross_section(const YAML::Node& config) {
+    std::string type = config["type"].as<std::string>();
+    if (type == "tint") {
+        auto reader = NetCDFReader(config["netcdf files"][0]["file path"]);
+        return temperature_interpolation(reader);
+    } else if (type == "CCl4+hv->Products") {
+        // ... compose primitives per config
+    }
+    // etc.
+}
+```
+
+This maps the existing config types (`"tint"`, `"O3"`, `"temperature based"`, etc.) to composed transforms.
+
+### Language bindings
+
+- **Python** (PyBind11): Wrap the C++ `Solver` and `PhotolysisCalculator` classes. Transforms can be specified as Python callables or by name (MUSICA maps names to C++ lambdas).
+- **JavaScript** (WASM): Compile C++ solver to WebAssembly via Emscripten. Only CPU path.
+- **Julia**: `ccall` into the C API wrapper.
+- **Fortran**: `iso_c_binding` into the C API wrapper (for legacy model integration).
+
+### Migration path
+
+1. New tuv-x library reaches feature parity with Fortran for Delta Eddington solver
+2. MUSICA adds the new library as an alternative dependency alongside the old one
+3. Regression tests verify identical output
+4. MUSICA switches default to new library
+5. Old Fortran tuv-x repo archived (kept for reference)
+
+### Key MUSICA references
+- [MUSICA repo](https://github.com/NCAR/musica) — `cmake/dependencies.cmake` for FetchContent setup
+- `include/musica/` — C++ API headers
+- `python/` — PyBind11 bindings
+- `javascript/` — WASM/Emscripten build
+- `julia/` — Julia wrapper
+- `fortran/` — Fortran interface via `iso_c_binding`
+
+### Existing TUV-x integration in MUSICA
+- `tutorials/` — TUV-x tutorials already exist in MUSICA
+- Current MUSICA builds tuv-x as `musica::tuvx` target
+- MUSICA uses `TUVX_GIT_REPOSITORY` and `TUVX_GIT_TAG` CMake variables for version control

--- a/.github/prompts/plan-tuvXCppSolverRewrite.prompt.md
+++ b/.github/prompts/plan-tuvXCppSolverRewrite.prompt.md
@@ -2,6 +2,105 @@
 
 **TL;DR**: Replace the Fortran-based TUV-x with a high-performance C++ photolysis rate constant calculator, developed on a clean branch (`cpp-rewrite`) in the existing `tuv-x` repo. The library provides a pure programmatic C++ API — no configuration files — with composable lambda-based transforms for cross-sections, quantum yields, and dose rates. Data structures use template policies to support both CPU SIMD (multi-column vectorization) and GPU (CUDA/HIP) execution. Delta Eddington solver ships first; Discrete Ordinate follows. MUSICA wraps this library and handles YAML/JSON configuration and Python/JS/Fortran bindings.
 
+### Target README Example
+
+This draft example is the API we are building toward. It should compile and run as-is when the library is complete. Keep it up to date as the API evolves — if the example gets ugly, the API needs work.
+
+```cpp
+#include <tuvx/solver.hpp>
+#include <tuvx/photolysis_calculator.hpp>
+#include <tuvx/grid.hpp>
+#include <tuvx/profile.hpp>
+#include <tuvx/radiative_transfer/radiator.hpp>
+#include <tuvx/radiative_transfer/radiation_field.hpp>
+
+#include <iomanip>
+#include <iostream>
+
+using Policy = tuvx::HostArrayPolicy;
+
+int main()
+{
+  // Define the wavelength grid, which is shared across all columns and is constant in time
+  tuvx::Grid<Policy> wavelength_grid("m", 1, 4);   // units, 1 column, 4 wavelength bins
+  wavelength_grid.SetEdges({ 280e-9, 300e-9, 320e-9, 340e-9, 400e-9 }); // SetEdges() uses edges to calculate mid-points internally
+
+  // create a solver for the radiation field
+  auto solver = tuvx::CpuSolverBuilder<tuvx::DeltaEddingtonParameters>(tuvx::DeltaEddingtonParameters::StandardParameters())
+    .WithWavelengthGrid(wavelength_grid)
+    .WithNumberOfVerticalMidpoints(2)
+    .WithRadiator("O2", tuvx::Library::CrossSections::O2) // these might come from a VERY SMALL set of built-in library cross-sections (maybe just O2, Air, and O3)
+    .WithRadiator("Air", tuvx::Library::CrossSections::Air)
+    .Build();
+
+  // get containers for the atmospheric state and radiation field
+  auto atm_state = solver.GetState(1);          // 1 column
+  auto rad_field = solver.GetRadiationField(1); // 1 column
+
+  // set the input state for the solver
+  atm_state.height[0].SetEdges({ 0.0, 5000.0, 10000.0 });   // set height grid for first column (0–5 km, 5–10 km)
+  atm_state.temperature[0].SetConstant(250.0);              // 250 K constant profile for first column
+  atm_state.pressure[0].SetMidpoints({ 50000.0, 20000.0 }); // 500 hPa at surface, 200 hPa at 10 km for first column
+  atm_state.air_density[0].SetMidpoints({ 42.0, 15.0 });    // 42 mol/m³ at surface, 15 mol/m³ at 10 km for first column
+
+  atm_state.solar_zenith_angle[0] = 0.5236;           // 30° in radians for first column
+  atm_state.earth_sun_distance[0] = 1.0;              // 1 AU for first column
+  atm_state.surface_albedo[0].SetConstant(0.1);       // 10% surface albedo for first column
+
+  // solve for the radiation field ---
+  auto result = solver.solve(atm_state, rad_field); // result holds solver stats, whether converged, etc.
+
+  // define photolysis reactions using lambda transforms
+  auto calc = rad_field.GetPhotolysisCalculator();
+
+  // Reaction 1: O3 + hv → O2 + O(1D)
+  //   Cross-section: temperature-dependent Gaussian centered at 300 nm
+  //   Quantum yield: constant 0.7
+  calc.add_reaction("O3->O2+O1D",
+    // cross-section transform (calculates weights)
+    [](const auto& state, auto& weights) {
+      weights.ForEachRow([&](double& weight, const double& wavelength, const double& temperature) {
+        double sigma_300 = 1.0e-22; // m² at 300 nm
+        double temp_factor = (temperature - 200.0) / 100.0; // simple linear temp dependence
+        double sigma = sigma_300 * std::exp(-std::pow((wavelength - 300e-9) / 10e-9, 2)) * (1 + temp_factor);
+        weight = sigma;
+
+      }, state.wavelength_grid.mid_points(), state.temperature.mid_points()); // access all wavelengths and temperatures across all columns, heights, wavelengths
+    },
+    // quantum yield transform (constant weights)
+    [](const auto& state, auto& weights) {
+      weights.set_constant(0.7);
+    }
+  );
+
+  // Reaction 2: NO2 + hv → NO + O
+  //   Cross-section: 5.0e-23 m² below 350 nm, 1.0e-24 m² above — built from combinators
+  //   Quantum yield: constant 0.5
+  calc.add_reaction("NO2->NO+O",
+    tuvx::add(
+      tuvx::in_region(0.0, 350e-9, tuvx::constant(5.0e-23)),   // 5.0e-23 m² for λ < 350 nm
+      tuvx::in_region(350e-9, 400e-9, tuvx::constant(1.0e-24)) // 1.0e-24 m² for λ ≥ 350 nm
+    ),
+    tuvx::constant(0.5)
+  );
+
+  // calculate photolysis rates
+  auto rates = calc.calculate(rad_field, atm_state);
+  rates.Print();
+
+  return 0;
+}
+```
+
+To build (assuming TUV-x is installed):
+
+```
+g++ -o photolysis photolysis.cpp -I/usr/local/tuvx/include -std=c++20
+./photolysis
+```
+
+**This example is our north star.** If any API change makes this example harder to read or write, that change needs strong justification.
+
 ## Phase 0: Project Scaffolding
 
 ### SI Units Policy
@@ -15,7 +114,7 @@ The TUV-x C++ library performs **no unit conversions** whatsoever. All input dat
 - **Pressure**: Pascals (Pa)
 - **Time**: seconds (s)
 - **Cross-sections**: m² (not cm²)
-- **Number density**: molecules/m³ (not molecules/cm³)
+- **Number density**: moles/m³ (not molecules/cm³)
 
 All outputs are in SI units. Any data files (e.g., legacy NetCDF files with wavelengths in nm) must be pre-converted to SI units before being consumed by TUV-x. The responsibility for unit conversion lies with the caller or the data preparation pipeline — not with the library itself.
 
@@ -153,33 +252,33 @@ This means solver functions never loop over columns explicitly — they express 
 
 ## Phase 2: Composable Transform System
 
-   **What is a transform?** A transform is a set of per-wavelength, per-height weights `[wavelength × height × column]` — conceptually a weight matrix that can be *applied* to the radiation field (element-wise multiplication). Cross-sections, quantum yields, and spectral weights are all transforms. Calculating a transform may depend on atmospheric conditions (T, P, density), but those are inputs to the *weight calculation*, not to the application. You first **calculate** a transform (produce the weight matrix), then **apply** it to the radiation field (multiply), then **reduce** (sum over wavelengths) to get rates.
+   **What is a transform?** A transform is a set of per-wavelength, per-height weights `[wavelength × height × column]` — conceptually a weight matrix that can be *applied* to the radiation field (element-wise multiplication). Cross-sections, quantum yields, and spectral weights are all transforms. Calculating a transform may depend on atmospheric state (T, P, density, constituent concentrations, etc.), but those are inputs to the *weight calculation*, not to the application. You first **calculate** a transform (produce the weight matrix), then **apply** it to the radiation field (multiply), then **reduce** (sum over wavelengths) to get rates.
 
 - [ ] 7. **Design the transform type system.** Define `TransformFunc` as a callable that **calculates** a transform — i.e., fills a weight array `[wavelength × height × column]` given the current atmospheric state:
    ```cpp
+   template<typename ArrayPolicy>
    using TransformFunc = std::function<void(
-       const Grid<ArrayPolicy>& wavelength_grid,
-       const Grid<ArrayPolicy>& altitude_grid,
-       const Profile<ArrayPolicy>& temperature,
-       const Profile<ArrayPolicy>& pressure,
-       const Profile<ArrayPolicy>& air_density,
-       Array3D<typename ArrayPolicy::value_type>& weights  // [wavelength × height × column] — the calculated transform
+       const AtmosphericState<ArrayPolicy>& state,          // grids, T, P, density, constituents, etc.
+       Array3D<typename ArrayPolicy::value_type>& weights   // [wavelength × height × column] — the calculated transform
    )>;
    ```
+   `TransformFunc` takes a single `AtmosphericState` rather than individual parameters so the signature is stable — adding new state fields (e.g., constituent concentrations for quenching yields) doesn't break existing transforms.
+
    **`TransformFunc` is the open, user-facing API.** Any callable matching this signature is a valid transform calculator — users can write raw lambdas, function objects, or free functions directly. No factory or wrapper is required:
    ```cpp
    // User-written transform — just a lambda that calculates weights:
-   TransformFunc<ArrayPolicy> my_cross_section = [coeff](const auto& wl_grid, const auto& alt_grid,
-       const auto& temperature, const auto& pressure, const auto& air_density, auto& weights) {
+   TransformFunc<ArrayPolicy> my_cross_section = [coeff](const auto& state, auto& weights) {
+       // Access state.wavelength_grid, state.temperature, state.pressure, etc.
        // Calculate cross-section weights using ForEachRow, ColumnView, etc.
    };
    ```
-   The weights include the column dimension because temperature, pressure, and density vary per column, so the calculated weights differ per column. The weights are later applied to the radiation field in Phase 3 (rate calculation).
+   The weights include the column dimension because atmospheric state varies per column, so the calculated weights differ per column. The weights are later applied to the radiation field in Phase 3 (rate calculation).
 
 - [ ] 8. **Implement convenience transform library.** Provide a library of pre-built factory functions that return `TransformFunc` callables — each one calculates a particular kind of weight matrix. These are **convenience utilities built on the same public API a user would use** — they are not special internal constructs. Each factory captures its parameters and returns a lambda that calculates weights matching the `TransformFunc` signature. Users can use these off-the-shelf, compose them with combinators, or ignore them entirely and write raw lambdas:
 
    | Factory function | Math | Useful for |
    |-----------|------|------------------------|
+   | `constant(value)` | Sets all weights to a single value | Flat quantum yields, unit weights |
    | `from_data(reader, interpolator)` | Tabulated data → model grid interpolation | Base cross-sections, quantum yields |
    | `temperature_interpolation(reader)` | $\sigma(\lambda,T) = \sigma_i + \frac{T-T_i}{T_{i+1}-T_i}(\sigma_{i+1}-\sigma_i)$ | T-dependent tint types |
    | `polynomial_scaling(coeffs, T_ref)` | $\sigma_0 \cdot P(T - T_{ref}, \lambda)$ | CCl4, acetone, ClONO2, HCFC |
@@ -251,23 +350,20 @@ This means solver functions never loop over columns explicitly — they express 
 
 ## Phase 6: Public API
 
-- [ ] 20. **Define the top-level solver API.** This replaces the Fortran `core_t`. The API is purely programmatic — no config files:
+- [ ] 20. **Define the top-level solver API.** This replaces the Fortran `core_t`. The API is purely programmatic — no config files. Radiators are configured at construction time (via a builder) and owned by the solver. The solver creates properly-sized containers for state and radiation field:
     ```cpp
     template<typename ArrayPolicy>
     class Solver {
-        // Configure solver with template policy for CPU or GPU
-        void solve(
-            const AtmosphericState<ArrayPolicy>& state,
-            const RadiatorState<ArrayPolicy>& radiator_state,
-            RadiationField<ArrayPolicy>& radiation_field   // output
-        );
+        AtmosphericState<ArrayPolicy> GetState(int num_columns);
+        RadiationField<ArrayPolicy> GetRadiationField(int num_columns);
+        SolveResult solve(const AtmosphericState<ArrayPolicy>& state, RadiationField<ArrayPolicy>& field);
     };
 
     // Full pipeline: solve radiation field then compute rates
     template<typename ArrayPolicy>
     class PhotolysisCalculator {
         void add_reaction(std::string name, TransformFunc<ArrayPolicy> cross_section, TransformFunc<ArrayPolicy> quantum_yield);
-        void calculate(const RadiationField<ArrayPolicy>& field, const AtmosphericState<ArrayPolicy>& state, Array3D<typename ArrayPolicy::value_type>& rates);
+        Array3D<typename ArrayPolicy::value_type> calculate(const RadiationField<ArrayPolicy>& field, const AtmosphericState<ArrayPolicy>& state);
     };
     ```
 
@@ -294,7 +390,7 @@ This means solver functions never loop over columns explicitly — they express 
 | Decision | Choice | Rationale |
 |----------|--------|-----------|
 | Language | C++ | Builds on existing partial port; native MUSICA integration; standard HPC ecosystem |
-| Transform API | Open callable signature (`TransformFunc`) | A transform is a weight matrix `[λ × z × col]`; `TransformFunc` *calculates* the weights from atmospheric state; any matching callable is a valid transform calculator; convenience factory library covers common patterns; combinators compose weight calculations; the weights are then *applied* to the radiation field separately (Phase 3) |
+| Transform API | Open callable signature (`TransformFunc`) | A transform is a weight matrix `[λ × z × col]`; `TransformFunc(state, weights)` *calculates* the weights from a single `AtmosphericState` object (extensible with constituents, surface properties, etc.); any matching callable is a valid transform calculator; convenience factory library covers common patterns; combinators compose weight calculations; the weights are then *applied* to the radiation field separately (Phase 3) |
 | GPU portability | Template policies | Lighter weight than Kokkos/SYCL; consistent with existing codebase; can wrap Kokkos later if needed |
 | Migration strategy | Clean branch in existing repo | Work on `cpp-rewrite` branch in the existing `tuv-x` repo; preserves issue tracker, CI config, and history; Fortran code is removed on the branch; branch replaces `main` when ready |
 | Data readers | Pluggable interface, NetCDF-C default | Future-proofs against format changes; no Fortran dependency |

--- a/.github/prompts/plan-tuvXCppSolverRewrite.prompt.md
+++ b/.github/prompts/plan-tuvXCppSolverRewrite.prompt.md
@@ -144,7 +144,9 @@ This means solver functions never loop over columns explicitly — they express 
 
 ## Phase 2: Composable Transform System
 
-- [ ] 7. **Design the transform type system.** Define `TransformFunc` as a callable that maps atmospheric state to a 3D output array `[wavelength × height × column]`:
+   **What is a transform?** A transform is a set of per-wavelength, per-height weights `[wavelength × height × column]` — conceptually a weight matrix that can be *applied* to the radiation field (element-wise multiplication). Cross-sections, quantum yields, and spectral weights are all transforms. Calculating a transform may depend on atmospheric conditions (T, P, density), but those are inputs to the *weight calculation*, not to the application. You first **calculate** a transform (produce the weight matrix), then **apply** it to the radiation field (multiply), then **reduce** (sum over wavelengths) to get rates.
+
+- [ ] 7. **Design the transform type system.** Define `TransformFunc` as a callable that **calculates** a transform — i.e., fills a weight array `[wavelength × height × column]` given the current atmospheric state:
    ```cpp
    using TransformFunc = std::function<void(
        const Grid<Policy>& wavelength_grid,
@@ -152,20 +154,20 @@ This means solver functions never loop over columns explicitly — they express 
        const Profile<Policy>& temperature,
        const Profile<Policy>& pressure,
        const Profile<Policy>& air_density,
-       Array3D<T>& output  // [wavelength × height × column]
+       Array3D<T>& weights  // [wavelength × height × column] — the calculated transform
    )>;
    ```
-   **`TransformFunc` is the open, user-facing API.** Any callable matching this signature is a valid transform — users can write raw lambdas, function objects, or free functions directly. No factory or wrapper is required:
+   **`TransformFunc` is the open, user-facing API.** Any callable matching this signature is a valid transform calculator — users can write raw lambdas, function objects, or free functions directly. No factory or wrapper is required:
    ```cpp
-   // User-written transform — just a lambda matching the signature:
+   // User-written transform — just a lambda that calculates weights:
    TransformFunc<Policy> my_cross_section = [coeff](const auto& wl_grid, const auto& alt_grid,
-       const auto& temperature, const auto& pressure, const auto& air_density, auto& output) {
-       // User's custom logic using ForEachRow, ColumnView, etc.
+       const auto& temperature, const auto& pressure, const auto& air_density, auto& weights) {
+       // Calculate cross-section weights using ForEachRow, ColumnView, etc.
    };
    ```
-   The output includes the column dimension because temperature, pressure, and density vary per column, so the computed values differ per column.
+   The weights include the column dimension because temperature, pressure, and density vary per column, so the calculated weights differ per column. The weights are later applied to the radiation field in Phase 3 (rate calculation).
 
-- [ ] 8. **Implement convenience transform library.** Provide a library of pre-built factory functions that return `TransformFunc` callables. These are **convenience utilities built on the same public API a user would use** — they are not special internal constructs. Each factory captures its parameters and returns a lambda matching the `TransformFunc` signature. Users can use these off-the-shelf, compose them with combinators, or ignore them entirely and write raw lambdas:
+- [ ] 8. **Implement convenience transform library.** Provide a library of pre-built factory functions that return `TransformFunc` callables — each one calculates a particular kind of weight matrix. These are **convenience utilities built on the same public API a user would use** — they are not special internal constructs. Each factory captures its parameters and returns a lambda that calculates weights matching the `TransformFunc` signature. Users can use these off-the-shelf, compose them with combinators, or ignore them entirely and write raw lambdas:
 
    | Factory function | Math | Useful for |
    |-----------|------|------------------------|
@@ -184,17 +186,17 @@ This means solver functions never loop over columns explicitly — they express 
 
    | Combinator | Description |
    |------------|-------------|
-   | `in_region(lambda_min, lambda_max, transform)` | Apply transform only in a wavelength sub-range; zero outside |
-   | `multiply(a, b)` | Run both transforms, multiply their outputs element-wise |
-   | `add(a, b)` | Run both transforms, add their outputs element-wise |
-   | `piecewise({region1: t1, region2: t2, ...})` | Different transforms in different wavelength regions |
-   | `clamp(transform, min, max)` | Clamp output values |
-   | `override_band(band_name, value, transform)` | Replace values in named spectral bands (Lyman-alpha, Schumann-Runge) |
-   | `scale(factor, transform)` | Multiply by constant factor |
+   | `in_region(lambda_min, lambda_max, transform)` | Calculate weights only where λ_min ≤ λ ≤ λ_max; zero outside |
+   | `multiply(a, b)` | Calculate both weight sets, multiply element-wise to produce composite weights |
+   | `add(a, b)` | Calculate both weight sets, add element-wise to produce composite weights |
+   | `piecewise({region1: t1, region2: t2, ...})` | Calculate different weights in different wavelength regions |
+   | `clamp(transform, min, max)` | Clamp calculated weight values |
+   | `override_band(band_name, value, transform)` | Replace weight values in named spectral bands (Lyman-alpha, Schumann-Runge) |
+   | `scale(factor, transform)` | Multiply calculated weights by constant factor |
 
-   **Why combinators instead of sequential application?** A `TransformFunc` *writes* to the output array — it doesn't modify an existing value. Applying two transforms in sequence would just overwrite the first result with the second. Combinators like `multiply(a, b)` internally run both transforms (one into the output, one into a temporary), then combine the results element-wise. This is the only way to combine two independent computations.
+   **Why combinators instead of sequential calculation?** A `TransformFunc` *writes* to the weight array — it doesn't modify an existing value. Calculating two transforms in sequence would just overwrite the first weight set with the second. Combinators like `multiply(a, b)` internally calculate both weight sets (one into the output, one into a temporary), then combine them element-wise to produce a single composite weight matrix.
 
-- [ ] 10. **Port existing cross-section algorithms as composed transforms.** For each of the 27 cross-section types in `src/cross_sections/`, express as a library factory, a composition of factories via combinators, or a direct user-written `TransformFunc` lambda. Example for CCl4:
+- [ ] 10. **Port existing cross-section algorithms as composed transforms.** For each of the 27 cross-section types in `src/cross_sections/`, express the weight calculation as a library factory, a composition of factories via combinators, or a direct user-written `TransformFunc` lambda. Example for CCl4:
     ```cpp
     auto ccl4_xs = multiply(
         from_data(netcdf_reader("CCl4.nc"), conserving_interpolator()),
@@ -210,7 +212,7 @@ This means solver functions never loop over columns explicitly — they express 
 
 ## Phase 3: Rate Calculation Engine
 
-- [ ] 13. **Implement photolysis rate calculator.** Port `src/photolysis_rates.F90`. The core operation is:
+- [ ] 13. **Implement photolysis rate calculator.** Port `src/photolysis_rates.F90`. The pipeline is: (1) **calculate** each reaction's cross-section and quantum yield transforms (weight matrices), (2) **apply** them to the radiation field (element-wise multiply: field × σ × φ × Δλ), (3) **reduce** by summing over wavelengths:
     $$J_i(z) = \sum_\lambda F(\lambda, z) \cdot \sigma_i(\lambda, z) \cdot \phi_i(\lambda, z) \cdot \Delta\lambda$$
     This is a batched dot product per height layer per reaction — highly parallelizable across columns and reactions. The API takes a solved `RadiationField`, a list of `(cross_section_transform, quantum_yield_transform)` pairs, and returns an `Array3D [reaction × height × column]`.
 
@@ -274,7 +276,7 @@ This means solver functions never loop over columns explicitly — they express 
 
 - **Unit tests** (GTest): Each transform factory function, combinator, interpolator, data reader, and solver step gets individual tests. Include tests of user-written `TransformFunc` lambdas to verify the API is fully open. Migrate existing C++ tests from the current repo.
 - **Regression tests**: Pre-compute reference outputs from the current Fortran solver for several standard configurations (`examples/tuv_5_4.json`, `examples/ts1_tsmlt.json`) and store as binary fixtures. The new C++ solver must match within floating-point tolerance.
-- **Cross-validation of transforms**: For each of the 27 cross-section types and 20 quantum yield types, compare the new composed-transform output against Fortran reference values at multiple temperature/pressure points.
+- **Cross-validation of transforms**: For each of the 27 cross-section types and 20 quantum yield types, compare the calculated weight matrices against Fortran reference values at multiple temperature/pressure points.
 - **Performance benchmarks**: Google Benchmark tests for multi-column solver throughput (1, 10, 100, 1000 columns) on CPU. CUDA/HIP benchmarks once GPU policy is implemented.
 - **MUSICA integration test**: End-to-end test through MUSICA's config-driven pipeline producing identical photolysis rates.
 
@@ -283,7 +285,7 @@ This means solver functions never loop over columns explicitly — they express 
 | Decision | Choice | Rationale |
 |----------|--------|-----------|
 | Language | C++ | Builds on existing partial port; native MUSICA integration; standard HPC ecosystem |
-| Transform API | Open callable signature (`TransformFunc`) | Any lambda/callable matching the signature is a valid transform; convenience factory library covers common patterns; combinators compose any transforms; config layer lives in MUSICA |
+| Transform API | Open callable signature (`TransformFunc`) | A transform is a weight matrix `[λ × z × col]`; `TransformFunc` *calculates* the weights from atmospheric state; any matching callable is a valid transform calculator; convenience factory library covers common patterns; combinators compose weight calculations; the weights are then *applied* to the radiation field separately (Phase 3) |
 | GPU portability | Template policies | Lighter weight than Kokkos/SYCL; consistent with existing codebase; can wrap Kokkos later if needed |
 | Migration strategy | New standalone repo | Clean separation; old Fortran repo stays as reference/validation; MUSICA switches dependency when ready |
 | Data readers | Pluggable interface, NetCDF-C default | Future-proofs against format changes; no Fortran dependency |

--- a/.github/prompts/plan-tuvXCppSolverRewrite.prompt.md
+++ b/.github/prompts/plan-tuvXCppSolverRewrite.prompt.md
@@ -1,6 +1,6 @@
 # Plan: TUV-x C++ Solver Library Rewrite
 
-**TL;DR**: Create a new standalone C++ library (new repo, e.g., `tuv-x-cpp`) that replaces the Fortran-based TUV-x with a high-performance photolysis rate constant calculator. The library provides a pure programmatic C++ API — no configuration files — with composable lambda-based transforms for cross-sections, quantum yields, and dose rates. Data structures use template policies to support both CPU SIMD (multi-column vectorization) and GPU (CUDA/HIP) execution. Delta Eddington solver ships first; Discrete Ordinate follows. MUSICA wraps this library and handles YAML/JSON configuration and Python/JS/Julia bindings.
+**TL;DR**: Replace the Fortran-based TUV-x with a high-performance C++ photolysis rate constant calculator, developed on a clean branch (`cpp-rewrite`) in the existing `tuv-x` repo. The library provides a pure programmatic C++ API — no configuration files — with composable lambda-based transforms for cross-sections, quantum yields, and dose rates. Data structures use template policies to support both CPU SIMD (multi-column vectorization) and GPU (CUDA/HIP) execution. Delta Eddington solver ships first; Discrete Ordinate follows. MUSICA wraps this library and handles YAML/JSON configuration and Python/JS/Fortran bindings.
 
 ## Phase 0: Project Scaffolding
 
@@ -19,9 +19,18 @@ The TUV-x C++ library performs **no unit conversions** whatsoever. All input dat
 
 All outputs are in SI units. Any data files (e.g., legacy NetCDF files with wavelengths in nm) must be pre-converted to SI units before being consumed by TUV-x. The responsibility for unit conversion lies with the caller or the data preparation pipeline — not with the library itself.
 
-- [ ] 1. **Create new repository** (`tuv-x-cpp` or chosen name) with CMake build system (CMake 3.21+ to match MUSICA). Configure languages `CXX` with optional `CUDA`/`HIP`. Set up GitHub Actions CI with strict quality gates: >95% unit test coverage enforced on PRs, valgrind memcheck on all tests, multi-compiler matrix (GCC, Clang, MSVC, Intel, NVHPC) across Linux/macOS/Windows, clang-tidy static analysis as a PR gate, and auto-generated formatting PRs via clang-format. Enforce legible naming conventions (no cryptic abbreviations).
+### Documentation Policy
 
-- [ ] 2. **Migrate reusable C++ code from current repo.** Port the following already-complete implementations from `include/tuvx/` into the new repo's `include/` and `src/`:
+Document as you go — every public header, class, function, and non-obvious implementation detail gets documentation **when it is written**, not as a separate phase. Keep it meaningful and succinct:
+
+- **Public API** (headers in `include/tuvx/`): Doxygen `///` comments on every class, function, and template parameter. State what it does, what the parameters mean, and any preconditions — not how it works internally.
+- **Non-obvious implementation details** (in `.cpp`/`.inl` files): Brief inline comments explaining *why*, not *what*. Algorithms ported from Fortran should reference the original subroutine name and source file.
+- **README**: Keep the top-level README current with build instructions, a usage example, and a link to the Doxygen-generated API docs.
+- **No verbose boilerplate**: Omit `@author`, `@date`, `@file`, and other noise. Don't restate what the code already says.
+
+- [ ] 1. **Create `cpp-rewrite` branch** in the existing `tuv-x` repo. Reset the branch to a clean state: remove Fortran source, legacy config, and unused build scaffolding. Set up CMake build system (CMake 3.21+ to match MUSICA). Configure languages `CXX` with optional `CUDA`/`HIP`. Set up GitHub Actions CI with strict quality gates: >95% unit test coverage enforced on PRs, valgrind memcheck on all tests, multi-compiler matrix (GCC, Clang, MSVC, Intel, NVHPC) across Linux/macOS/Windows, clang-tidy static analysis as a PR gate, and auto-generated formatting PRs via clang-format. Enforce legible naming conventions (no cryptic abbreviations).
+
+- [ ] 2. **Restructure existing C++ code.** Reorganize the already-complete implementations from `include/tuvx/` into a clean directory structure on the `cpp-rewrite` branch:
    - `Array1D<T>` — new implementation (see below), modeled after `Array2D`/`Array3D`
    - `Array2D<T>`, `Array3D<T>` — `include/tuvx/util/array2d.hpp`, `include/tuvx/util/array3d.hpp`
    - `Grid<ArrayPolicy>` — `include/tuvx/grid.hpp`
@@ -270,7 +279,7 @@ This means solver functions never loop over columns explicitly — they express 
 
 ## Phase 8: MUSICA Integration
 
-- [ ] 23. **Update MUSICA to consume the new library.** MUSICA's CMake system (`TUVX_GIT_REPOSITORY` / `TUVX_GIT_TAG`) uses FetchContent for tuv-x. Point it at the new repo. Build the YAML/JSON configuration layer in MUSICA that maps config files to the pure C++ API, translating `"type": "tint"` into the corresponding composed lambda transforms. MUSICA's PyBind11 / JS / Julia bindings wrap the new C API.
+- [ ] 23. **Update MUSICA to consume the new library.** MUSICA's CMake system (`TUVX_GIT_REPOSITORY` / `TUVX_GIT_TAG`) uses FetchContent for tuv-x. Point it at the `cpp-rewrite` branch (and eventually `main` once merged). Build the YAML/JSON configuration layer in MUSICA that maps config files to the pure C++ API, translating `"type": "tint"` into the corresponding composed lambda transforms. MUSICA's PyBind11 / JS / Fortran bindings wrap the new C API.
 
 ## Verification
 
@@ -287,9 +296,10 @@ This means solver functions never loop over columns explicitly — they express 
 | Language | C++ | Builds on existing partial port; native MUSICA integration; standard HPC ecosystem |
 | Transform API | Open callable signature (`TransformFunc`) | A transform is a weight matrix `[λ × z × col]`; `TransformFunc` *calculates* the weights from atmospheric state; any matching callable is a valid transform calculator; convenience factory library covers common patterns; combinators compose weight calculations; the weights are then *applied* to the radiation field separately (Phase 3) |
 | GPU portability | Template policies | Lighter weight than Kokkos/SYCL; consistent with existing codebase; can wrap Kokkos later if needed |
-| Migration strategy | New standalone repo | Clean separation; old Fortran repo stays as reference/validation; MUSICA switches dependency when ready |
+| Migration strategy | Clean branch in existing repo | Work on `cpp-rewrite` branch in the existing `tuv-x` repo; preserves issue tracker, CI config, and history; Fortran code is removed on the branch; branch replaces `main` when ready |
 | Data readers | Pluggable interface, NetCDF-C default | Future-proofs against format changes; no Fortran dependency |
 | Solver order | Delta Eddington first | Simpler two-stream method; validates full pipeline before tackling DISORT's 3,700 lines |
 | Configuration | No config files in solver library | Clean separation of concerns; MUSICA handles all configuration mapping |
 | Units | SI only, no conversions | All inputs/outputs in SI units (m, rad, s, K, Pa); no unit conversion code in the library; callers and data pipelines are responsible for providing SI data |
 | MICM consistency | Align API conventions with MICM | Both TUV-x and MICM are MUSICA components; consistent syntax (`operator[]`, `ForEachRow`, `ColumnView`, `Function` factory, `ArrayPolicy` template pattern) reduces cognitive load for users working across both libraries. Diverge only when TUV-x requirements demand it (e.g., `Array1D` instead of `std::vector`) |
+| Documentation | Inline, as-you-go | Every public API gets succinct Doxygen comments when written; implementation comments explain *why* not *what*; no verbose boilerplate (`@author`, `@date`, `@file`); README stays current |

--- a/.github/prompts/plan-tuvXCppSolverRewrite.prompt.md
+++ b/.github/prompts/plan-tuvXCppSolverRewrite.prompt.md
@@ -149,18 +149,18 @@ This means solver functions never loop over columns explicitly — they express 
 - [ ] 7. **Design the transform type system.** Define `TransformFunc` as a callable that **calculates** a transform — i.e., fills a weight array `[wavelength × height × column]` given the current atmospheric state:
    ```cpp
    using TransformFunc = std::function<void(
-       const Grid<Policy>& wavelength_grid,
-       const Grid<Policy>& altitude_grid,
-       const Profile<Policy>& temperature,
-       const Profile<Policy>& pressure,
-       const Profile<Policy>& air_density,
-       Array3D<T>& weights  // [wavelength × height × column] — the calculated transform
+       const Grid<ArrayPolicy>& wavelength_grid,
+       const Grid<ArrayPolicy>& altitude_grid,
+       const Profile<ArrayPolicy>& temperature,
+       const Profile<ArrayPolicy>& pressure,
+       const Profile<ArrayPolicy>& air_density,
+       Array3D<typename ArrayPolicy::value_type>& weights  // [wavelength × height × column] — the calculated transform
    )>;
    ```
    **`TransformFunc` is the open, user-facing API.** Any callable matching this signature is a valid transform calculator — users can write raw lambdas, function objects, or free functions directly. No factory or wrapper is required:
    ```cpp
    // User-written transform — just a lambda that calculates weights:
-   TransformFunc<Policy> my_cross_section = [coeff](const auto& wl_grid, const auto& alt_grid,
+   TransformFunc<ArrayPolicy> my_cross_section = [coeff](const auto& wl_grid, const auto& alt_grid,
        const auto& temperature, const auto& pressure, const auto& air_density, auto& weights) {
        // Calculate cross-section weights using ForEachRow, ColumnView, etc.
    };

--- a/.github/prompts/plan-tuvXCppSolverRewrite.prompt.md
+++ b/.github/prompts/plan-tuvXCppSolverRewrite.prompt.md
@@ -4,6 +4,21 @@
 
 ## Phase 0: Project Scaffolding
 
+### SI Units Policy
+
+The TUV-x C++ library performs **no unit conversions** whatsoever. All input data — whether provided programmatically or read from data files — must already be in SI units before use:
+
+- **Wavelength**: meters (m), not nanometers
+- **Distance/altitude**: meters (m), not kilometers
+- **Angles**: radians (rad), not degrees
+- **Temperature**: Kelvin (K)
+- **Pressure**: Pascals (Pa)
+- **Time**: seconds (s)
+- **Cross-sections**: m² (not cm²)
+- **Number density**: molecules/m³ (not molecules/cm³)
+
+All outputs are in SI units. Any data files (e.g., legacy NetCDF files with wavelengths in nm) must be pre-converted to SI units before being consumed by TUV-x. The responsibility for unit conversion lies with the caller or the data preparation pipeline — not with the library itself.
+
 - [ ] 1. **Create new repository** (`tuv-x-cpp` or chosen name) with CMake build system (CMake 3.21+ to match MUSICA). Configure languages `CXX` with optional `CUDA`/`HIP`. Set up GitHub Actions CI with strict quality gates: >95% unit test coverage enforced on PRs, valgrind memcheck on all tests, multi-compiler matrix (GCC, Clang, MSVC, Intel, NVHPC) across Linux/macOS/Windows, clang-tidy static analysis as a PR gate, and auto-generated formatting PRs via clang-format. Enforce legible naming conventions (no cryptic abbreviations).
 
 - [ ] 2. **Migrate reusable C++ code from current repo.** Port the following already-complete implementations from `include/tuvx/` into the new repo's `include/` and `src/`:
@@ -37,7 +52,7 @@
    - **Step 5**: Solve tridiagonal system using existing `TridiagonalMatrix::Solve()` (Thomas algorithm)
    - **Step 6**: Back-substitute $Y$ to compute fluxes and actinic flux components
    - All operations process batches of columns; the column dimension is innermost for SIMD/GPU vectorization
-   - All units in SI (meters, radians, seconds) — convert from Fortran's km/nm/degrees at API boundaries
+   - All units in SI (meters, radians, seconds) — no unit conversions in solver code; all input data must be provided in SI units
 
 - [ ] 6. **Regression test against Fortran solver.** Adapt the existing test harness in `test/regression/solvers/` to validate the new C++ solver against pre-computed Fortran reference outputs stored as binary/NetCDF files. This decouples testing from the Fortran build.
 
@@ -84,8 +99,8 @@
     ```cpp
     auto ccl4_xs = compose(
         from_data(netcdf_reader("CCl4.nc"), conserving_interpolator()),
-        in_region(194_nm, 250_nm,
-            polynomial_scaling({b0, b1, b2, b3, b4}, 295.0_K))
+        in_region(194e-9, 250e-9,
+            polynomial_scaling({b0, b1, b2, b3, b4}, 295.0))
     );
     ```
     For complex cases like O3 (4 regions, refraction correction) or H2O2 (blended polynomials via Boltzmann $\chi$), use `piecewise()` and `analytic()` with custom lambdas.
@@ -173,3 +188,4 @@
 | Data readers | Pluggable interface, NetCDF-C default | Future-proofs against format changes; no Fortran dependency |
 | Solver order | Delta Eddington first | Simpler two-stream method; validates full pipeline before tackling DISORT's 3,700 lines |
 | Configuration | No config files in solver library | Clean separation of concerns; MUSICA handles all configuration mapping |
+| Units | SI only, no conversions | All inputs/outputs in SI units (m, rad, s, K, Pa); no unit conversion code in the library; callers and data pipelines are responsible for providing SI data |

--- a/.github/prompts/plan-tuvXCppSolverRewrite.prompt.md
+++ b/.github/prompts/plan-tuvXCppSolverRewrite.prompt.md
@@ -1,0 +1,175 @@
+# Plan: TUV-x C++ Solver Library Rewrite
+
+**TL;DR**: Create a new standalone C++ library (new repo, e.g., `tuv-x-cpp`) that replaces the Fortran-based TUV-x with a high-performance photolysis rate constant calculator. The library provides a pure programmatic C++ API — no configuration files — with composable lambda-based transforms for cross-sections, quantum yields, and dose rates. Data structures use template policies to support both CPU SIMD (multi-column vectorization) and GPU (CUDA/HIP) execution. Delta Eddington solver ships first; Discrete Ordinate follows. MUSICA wraps this library and handles YAML/JSON configuration and Python/JS/Julia bindings.
+
+## Phase 0: Project Scaffolding
+
+- [ ] 1. **Create new repository** (`tuv-x-cpp` or chosen name) with CMake build system (CMake 3.21+ to match MUSICA). Configure languages `CXX` with optional `CUDA`/`HIP`. Set up GitHub Actions CI with strict quality gates: >95% unit test coverage enforced on PRs, valgrind memcheck on all tests, multi-compiler matrix (GCC, Clang, MSVC, Intel, NVHPC) across Linux/macOS/Windows, clang-tidy static analysis as a PR gate, and auto-generated formatting PRs via clang-format. Enforce legible naming conventions (no cryptic abbreviations).
+
+- [ ] 2. **Migrate reusable C++ code from current repo.** Port the following already-complete implementations from `include/tuvx/` into the new repo's `include/` and `src/`:
+   - `Array2D<T>`, `Array3D<T>` — `include/tuvx/util/array2d.hpp`, `include/tuvx/util/array3d.hpp`
+   - `Grid<ArrayPolicy>` — `include/tuvx/grid.hpp`
+   - `Profile<ArrayPolicy>` — `include/tuvx/profile.hpp`
+   - `RadiatorState<ArrayPolicy>` — `include/tuvx/radiative_transfer/radiator.hpp`
+   - `RadiationField`, `RadiationFieldComponents` — `include/tuvx/radiative_transfer/radiation_field.hpp`
+   - `TridiagonalMatrix<T>`, `Solve()` — `include/tuvx/linear_algebra/linear_algebra.hpp`
+   - Existing GTest tests for all of the above
+   - Existing Google Benchmark for tridiagonal solver — `benchmark/benchmark_tridiagonal_solver.cpp`
+
+- [ ] 3. **Define template policy system for CPU/GPU portability.** Extend the existing `ArrayPolicy` pattern into a coherent execution/memory policy. The solver algorithms are written once, templated on a single `ArrayPolicy` — from the algorithm's perspective, array access is identical regardless of backing storage:
+
+   - `ArrayPolicy` controls: memory allocation (where), data layout (how), and element access (syntax)
+   - `HostArrayPolicy` — `std::vector`-backed; SoA layout with column index innermost for compiler auto-vectorization (SIMD)
+   - `DeviceArrayPolicy` — CUDA/HIP device memory; coalesced access patterns; same element access syntax via `__host__ __device__` accessors
+   - Solver functions are templated on `ArrayPolicy` and written exactly once — no `#ifdef` branching, no runtime dispatch
+   - All core types (`Grid`, `Profile`, `RadiatorState`, `RadiationField`, `TridiagonalMatrix`) are already templated on `ArrayPolicy` in the existing codebase; this pattern is preserved and extended
+
+
+## Phase 1: Delta Eddington Solver
+
+- [ ] 4. **Implement spherical geometry utilities.** Port the pseudo-spherical correction from `src/spherical_geometry.F90` and the slant optical depth calculation from `src/radiative_transfer/solver.F90`. These compute the effective solar path through curved atmospheric layers. Pure functions, no state.
+
+- [ ] 5. **Implement Delta Eddington solver.** Replace the placeholder in `include/tuvx/radiative_transfer/solvers/delta_eddington.inl` with the actual algorithm from `src/radiative_transfer/solvers/delta_eddington.F90`. The implementation follows 6 steps documented in [issue #64](https://github.com/NCAR/tuv-x/issues/64):
+   - **Step 1**: Delta-scale optical properties; compute gamma coefficients ($\gamma_1$ through $\gamma_4$, $\lambda$, $\Gamma$) — per layer, per wavelength, per column
+   - **Step 2**: Compute solar source functions $C^+(\tau)$ and $C^-(\tau)$
+   - **Step 3**: Assemble tridiagonal system coefficients ($e_1$ through $e_4$; $A_n$, $B_n$, $D_n$ matrix diagonals)
+   - **Step 4**: Assemble right-hand side $E_n$ with surface albedo boundary condition
+   - **Step 5**: Solve tridiagonal system using existing `TridiagonalMatrix::Solve()` (Thomas algorithm)
+   - **Step 6**: Back-substitute $Y$ to compute fluxes and actinic flux components
+   - All operations process batches of columns; the column dimension is innermost for SIMD/GPU vectorization
+   - All units in SI (meters, radians, seconds) — convert from Fortran's km/nm/degrees at API boundaries
+
+- [ ] 6. **Regression test against Fortran solver.** Adapt the existing test harness in `test/regression/solvers/` to validate the new C++ solver against pre-computed Fortran reference outputs stored as binary/NetCDF files. This decouples testing from the Fortran build.
+
+## Phase 2: Composable Transform System
+
+- [ ] 7. **Design the transform type system.** Define a `Transform<Policy>` as a callable that maps atmospheric state to a 2D array `[wavelength × height]`:
+   ```cpp
+   using TransformFunc = std::function<void(
+       const Grid<Policy>& wavelength_grid,
+       const Grid<Policy>& altitude_grid,
+       const Profile<Policy>& temperature,
+       const Profile<Policy>& pressure,
+       const Profile<Policy>& air_density,
+       Array2D<T>& output  // [wavelength × height]
+   )>;
+   ```
+   This is the fundamental signature for cross-sections, quantum yields, and spectral weights.
+
+- [ ] 8. **Implement composable transform primitives.** Each returns a `TransformFunc` (or equivalent callable). These are the building blocks:
+
+   | Primitive | Replaces | Description |
+   |-----------|----------|-------------|
+   | `from_data(reader, interpolator)` | Base `cross_section_t` | Load tabulated data via pluggable reader; interpolate to model grid |
+   | `temperature_interpolation(reader)` | `tint` | Linear interpolation between tabulated T-dependent data sets |
+   | `polynomial_scaling(coeffs, T_ref)` | CCl4, acetone, ClONO2 | $\sigma_0 \cdot P(T - T_{ref}, \lambda)$ |
+   | `exponential_scaling(coeffs, T_ref)` | CFC-11, RONO2, N2O5 | $\sigma_0 \cdot \exp(f(T, \lambda))$ |
+   | `linear_correction(slope_data)` | CH2O | $\sigma_0 + \beta \cdot \Delta T$ |
+   | `analytic(lambda_expr)` | Rayleigh, nitroxy compounds | User-supplied lambda for analytic formulas |
+   | `stern_volmer(phi0, k)` | CH2O quantum yield | Quenching: $1/(1/\phi_0 + k \cdot M)$ |
+   | `parameterized(type, params)` | Taylor/Burkholder/Harwood | Pluggable parameterization strategies |
+
+- [ ] 9. **Implement transform combinators.** These compose primitives:
+
+   | Combinator | Description |
+   |------------|-------------|
+   | `in_region(lambda_min, lambda_max, transform)` | Apply transform only in a wavelength sub-range; zero outside |
+   | `compose(base, modifier)` | Apply modifier to base output (multiply, add) |
+   | `piecewise({region1: t1, region2: t2, ...})` | Different transforms in different wavelength regions |
+   | `clamp(transform, min, max)` | Clamp output values |
+   | `override_band(band_name, value, transform)` | Replace values in named spectral bands (Lyman-alpha, Schumann-Runge) |
+   | `scale(factor, transform)` | Multiply by constant factor |
+
+- [ ] 10. **Port existing cross-section algorithms as composed transforms.** For each of the 27 cross-section types in `src/cross_sections/`, express as a composition of primitives. Example for CCl4:
+    ```cpp
+    auto ccl4_xs = compose(
+        from_data(netcdf_reader("CCl4.nc"), conserving_interpolator()),
+        in_region(194_nm, 250_nm,
+            polynomial_scaling({b0, b1, b2, b3, b4}, 295.0_K))
+    );
+    ```
+    For complex cases like O3 (4 regions, refraction correction) or H2O2 (blended polynomials via Boltzmann $\chi$), use `piecewise()` and `analytic()` with custom lambdas.
+
+- [ ] 11. **Port quantum yield algorithms** (~20 types in `src/quantum_yields/`) using the same primitive/combinator system. Most reuse the same primitives; `stern_volmer`, `analytic`, and `temperature_interpolation` cover the majority.
+
+- [ ] 12. **Port spectral weight algorithms** (~12 types in `src/spectral_weights/`) — these are simpler wavelength-only transforms (`gaussian`, `notch_filter`, `exponential_decay`, etc.).
+
+## Phase 3: Rate Calculation Engine
+
+- [ ] 13. **Implement photolysis rate calculator.** Port `src/photolysis_rates.F90`. The core operation is:
+    $$J_i(z) = \sum_\lambda F(\lambda, z) \cdot \sigma_i(\lambda, z) \cdot \phi_i(\lambda, z) \cdot \Delta\lambda$$
+    This is a batched dot product per height layer per reaction — highly parallelizable across columns and reactions. The API takes a solved `RadiationField`, a list of `(cross_section_transform, quantum_yield_transform)` pairs, and returns a 2D array `[reaction × height × column]`.
+
+- [ ] 14. **Implement dose rate calculator.** Port `src/dose_rates.F90`. Similar structure: spectral irradiance × spectral weight → dose rate per height.
+
+- [ ] 15. **Implement heating rate calculator.** Port the heating rate logic from `src/heating_rates.F90`.
+
+## Phase 4: Radiator and Atmospheric State
+
+- [ ] 16. **Implement radiator accumulation.** Port the radiator system from `src/radiative_transfer/radiators/`. In the new API, radiators are objects that provide optical depth, single-scattering albedo, and asymmetry parameter arrays. The `RadiatorState::Accumulate()` method (currently a placeholder) sums contributions from multiple radiators. Host models provide radiator data directly via the C++ API.
+
+- [ ] 17. **Implement Lyman-Alpha and Schumann-Runge band parameterization.** Port `src/la_sr_bands.F90` — this handles special UV absorption bands of O₂ that require separate treatment from the main solver.
+
+- [ ] 18. **Implement interpolation utilities.** Port the 4 interpolator types from `src/interpolate.F90` (linear, conserving, fractional_source, fractional_target) as standalone functions/objects used by the data reader system.
+
+## Phase 5: Data Reader Abstraction
+
+- [ ] 19. **Define pluggable data reader interface.** Abstract interface for loading cross-section/quantum yield parameter data:
+    ```cpp
+    class DataReader {
+        virtual Array2D<double> read_parameters(const std::string& variable_prefix) = 0;
+        virtual std::vector<double> read_wavelengths() = 0;
+        virtual std::vector<double> read_temperatures() = 0;  // optional
+    };
+    ```
+    Implement `NetCDFReader` using NetCDF-C (no Fortran dependency). This reads the existing ~160 `.nc` files unchanged. Additional readers (HDF5, CSV, binary) can be added later.
+
+## Phase 6: Public API
+
+- [ ] 20. **Define the top-level solver API.** This replaces the Fortran `core_t`. The API is purely programmatic — no config files:
+    ```cpp
+    class Solver {
+        // Configure solver with template policy for CPU or GPU
+        void solve(
+            const std::vector<Column>& columns,  // batch of atmospheric columns
+            const SolverOptions& options,          // solver type, surface albedo, etc.
+            RadiationField& radiation_field        // output
+        );
+    };
+
+    // Full pipeline: solve radiation field then compute rates
+    class PhotolysisCalculator {
+        void add_reaction(std::string name, TransformFunc cross_section, TransformFunc quantum_yield);
+        void calculate(const RadiationField& field, const AtmosphericState& state, RateOutput& output);
+    };
+    ```
+
+- [ ] 21. **C API wrapper.** Provide a `extern "C"` API for FFI consumption by MUSICA's Fortran interface, Python (via ctypes as fallback), and other languages. This mirrors how the current regression test in `test/regression/solvers/delta_eddington.hpp` defines C-interop structs.
+
+## Phase 7: Discrete Ordinate Solver (Later)
+
+- [ ] 22. **Port the DISORT solver.** The 3,700-line Fortran DISORT implementation in `src/radiative_transfer/solvers/discrete_ordinant_util.F90` is a well-known community code. Port the `PSNDO` subroutine and supporting functions to C++ with the same template policy system. This supports 2–32 even streams and is computationally heavier — GPU acceleration here will be most impactful.
+
+## Phase 8: MUSICA Integration
+
+- [ ] 23. **Update MUSICA to consume the new library.** MUSICA's CMake system (`TUVX_GIT_REPOSITORY` / `TUVX_GIT_TAG`) uses FetchContent for tuv-x. Point it at the new repo. Build the YAML/JSON configuration layer in MUSICA that maps config files to the pure C++ API, translating `"type": "tint"` into the corresponding composed lambda transforms. MUSICA's PyBind11 / JS / Julia bindings wrap the new C API.
+
+## Verification
+
+- **Unit tests** (GTest): Each transform primitive, combinator, interpolator, data reader, and solver step gets individual tests. Migrate existing C++ tests from the current repo.
+- **Regression tests**: Pre-compute reference outputs from the current Fortran solver for several standard configurations (`examples/tuv_5_4.json`, `examples/ts1_tsmlt.json`) and store as binary fixtures. The new C++ solver must match within floating-point tolerance.
+- **Cross-validation of transforms**: For each of the 27 cross-section types and 20 quantum yield types, compare the new composed-transform output against Fortran reference values at multiple temperature/pressure points.
+- **Performance benchmarks**: Google Benchmark tests for multi-column solver throughput (1, 10, 100, 1000 columns) on CPU. CUDA/HIP benchmarks once GPU policy is implemented.
+- **MUSICA integration test**: End-to-end test through MUSICA's config-driven pipeline producing identical photolysis rates.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Language | C++ | Builds on existing partial port; native MUSICA integration; standard HPC ecosystem |
+| Transform API | Lambda/functional composables | Removes ~3,000 lines of factory/config dispatch code; composable and testable; config layer lives in MUSICA |
+| GPU portability | Template policies | Lighter weight than Kokkos/SYCL; consistent with existing codebase; can wrap Kokkos later if needed |
+| Migration strategy | New standalone repo | Clean separation; old Fortran repo stays as reference/validation; MUSICA switches dependency when ready |
+| Data readers | Pluggable interface, NetCDF-C default | Future-proofs against format changes; no Fortran dependency |
+| Solver order | Delta Eddington first | Simpler two-stream method; validates full pipeline before tackling DISORT's 3,700 lines |
+| Configuration | No config files in solver library | Clean separation of concerns; MUSICA handles all configuration mapping |

--- a/.github/prompts/plan-tuvXCppSolverRewrite.prompt.md
+++ b/.github/prompts/plan-tuvXCppSolverRewrite.prompt.md
@@ -35,11 +35,95 @@ All outputs are in SI units. Any data files (e.g., legacy NetCDF files with wave
 - [ ] 3. **Define template policy system for CPU/GPU portability.** Extend the existing `ArrayPolicy` pattern into a coherent execution/memory policy. The solver algorithms are written once, templated on a single `ArrayPolicy` — from the algorithm's perspective, array access is identical regardless of backing storage:
 
    - `ArrayPolicy` controls: memory allocation (where), data layout (how), and element access (syntax)
-   - `HostArrayPolicy` — `std::vector`-backed; SoA layout with column index innermost for compiler auto-vectorization (SIMD)
-   - `DeviceArrayPolicy` — CUDA/HIP device memory; coalesced access patterns; same element access syntax via `__host__ __device__` accessors
+   - `HostArrayPolicy` — `std::vector`-backed; data layout chosen for compiler auto-vectorization (SIMD)
+   - `DeviceArrayPolicy` — CUDA/HIP device memory; data layout chosen for coalesced access; same element access syntax via `__host__ __device__` accessors
    - Solver functions are templated on `ArrayPolicy` and written exactly once — no `#ifdef` branching, no runtime dispatch
    - All core types (`Grid`, `Profile`, `RadiatorState`, `RadiationField`, `TridiagonalMatrix`) are already templated on `ArrayPolicy` in the existing codebase; this pattern is preserved and extended
    - **`Array1D<T>`**: Create a new 1D array type following the same pattern as `Array2D<T>` and `Array3D<T>`. This replaces all uses of `std::vector` in APIs that interact with `Grid`/`Profile`/policy-backed data, ensuring consistency when data is device-resident. `Array1D` must support the same `ArrayPolicy`-controlled memory allocation and access as the 2D/3D types. **No `std::vector` should appear in any function signature that also takes policy-backed types** — use `Array1D` instead
+
+### Bulk Operations API (MICM-Consistent)
+
+Raw element access (`array[i][j]`, `array[i][j][k]`) is available for setup and debugging, but **solver hot paths must use the bulk operations API** for layout-independent parallelization. This API follows the same design as MICM's `Matrix`/`VectorMatrix` pattern (both are MUSICA components and should present a consistent interface to users).
+
+The bulk operations API provides three core abstractions:
+
+#### Element access — square-bracket syntax
+
+All array types use `operator[]` chaining for logical element access, matching MICM's convention:
+```cpp
+Array1D<double> a(num_columns);
+a[col] = 1.0;
+
+Array2D<double> b(num_sections, num_columns);
+b[section][col] = 2.0;
+
+Array3D<double> c(num_wavelengths, num_layers, num_columns);
+c[wl][layer][col] = 3.0;
+```
+The `operator[]` returns a proxy/view object whose own `operator[]` resolves to the next dimension. The underlying index computation is policy-defined — the square-bracket chain provides logical access without prescribing physical layout.
+
+#### `ForEachRow` — layout-agnostic bulk iteration
+
+Operates on all elements along the innermost logical dimension (columns) simultaneously. The policy implementation decides how to vectorize/parallelize:
+```cpp
+// Given a 2D array [sections × columns]:
+array.ForEachRow(
+    [](const double& a, double& b) { b = a * 2.0; },
+    array.GetConstColumnView(0),   // read from column 0
+    array.GetColumnView(1)         // write to column 1
+);
+```
+`ForEachRow` takes a lambda plus any number of column views (or `Array1D` vectors). The lambda receives one element per argument per row. The policy controls iteration order and vectorization.
+
+Column views provide layout-abstracted access to a single column's data across all rows:
+- `GetColumnView(col)` — mutable view
+- `GetConstColumnView(col)` — read-only view
+- `GetRowVariable()` — temporary per-row storage (for intermediate calculations)
+
+#### `ArrayPolicy::Function` — reusable policy-compiled operations
+
+For performance-critical operations that are called repeatedly (e.g., every solver timestep), create a reusable function object. This allows the policy to pre-compute layout metadata and generate optimized iteration patterns:
+```cpp
+auto func = Array3D<double>::Function(
+    [](auto&& arr) {
+        auto tmp = arr.GetRowVariable();
+        arr.ForEachRow(
+            [](const double& a, const double& b, double& t)
+            { t = a + b; },
+            arr.GetConstColumnView(0),
+            arr.GetConstColumnView(1),
+            tmp);
+        arr.ForEachRow(
+            [](const double& t, double& c) { c = t * 2.0; },
+            tmp,
+            arr.GetColumnView(2));
+    }, prototype_array);  // prototype provides type/dimension info
+
+// Reuse with different arrays of the same column count:
+func(array_a);  // OK — applies optimized operation
+func(array_b);  // OK — different row count is fine
+```
+Column counts are validated at invocation time; row counts may differ from the prototype. This matches MICM's `MatrixPolicy::Function` factory exactly.
+
+### Multi-Column Architecture
+
+The solver always operates on a **set of columns simultaneously**. Every `Array1D`, `Array2D`, and `Array3D` in the solver pipeline carries a column dimension:
+
+| Array type | Logical dimensions | Column semantics | Examples |
+|-----------|-------------------|------------------|----------|
+| `Array1D` | `(column)` | One scalar per column | solar zenith angle, surface albedo |
+| `Array2D` | `(X, column)` | 1D data per column | grid mid-points/edges, profile values |
+| `Array3D` | `(X, Y, column)` | 2D data per column | optical depth `(wavelength, layer, column)`, cross-section output `(wavelength, height, column)` |
+
+These are *logical* dimensions — the underlying memory layout and dimension ordering is determined entirely by the concrete `ArrayPolicy` implementation. Solver code accesses elements by logical index using square-bracket syntax (e.g., `array[wavelength_idx][layer_idx][column_idx]`) and the policy maps that to the optimal physical layout.
+
+Solver hot paths use the **bulk operations API** (`ForEachRow`, `ColumnView`, `Function`) rather than element-by-element access. Solver code is written as bulk operations on `ArrayXD` data — the same operation applies to every column. The concrete `ArrayPolicy` implementation decides how to parallelize across the column dimension:
+- `HostArrayPolicy`: layout optimized for compiler auto-vectorization (SIMD) across columns
+- `DeviceArrayPolicy`: layout optimized for coalesced GPU memory access
+
+This means solver functions never loop over columns explicitly — they express element-wise or reduction operations via `ForEachRow` on the full `ArrayXD`, and the policy handles parallelization. Performance-critical operations (e.g., tridiagonal solve, delta-scaling) should use `ArrayPolicy::Function` to create reusable, policy-optimized function objects.
+
+**Exception**: `DataReader` returns (`Array1D` for wavelengths, `Array2D` for parameter tables) do *not* have a column dimension — these are static reference data shared across all columns. The column dimension is introduced when this data is broadcast into per-column arrays during transform evaluation.
 
 
 ## Phase 1: Delta Eddington Solver
@@ -53,14 +137,14 @@ All outputs are in SI units. Any data files (e.g., legacy NetCDF files with wave
    - **Step 4**: Assemble right-hand side $E_n$ with surface albedo boundary condition
    - **Step 5**: Solve tridiagonal system using existing `TridiagonalMatrix::Solve()` (Thomas algorithm)
    - **Step 6**: Back-substitute $Y$ to compute fluxes and actinic flux components
-   - All operations process batches of columns; the column dimension is innermost for SIMD/GPU vectorization
+   - All operations process batches of columns; the `ArrayPolicy` determines the optimal data layout for parallelization
    - All units in SI (meters, radians, seconds) — no unit conversions in solver code; all input data must be provided in SI units
 
 - [ ] 6. **Regression test against Fortran solver.** Adapt the existing test harness in `test/regression/solvers/` to validate the new C++ solver against pre-computed Fortran reference outputs stored as binary/NetCDF files. This decouples testing from the Fortran build.
 
 ## Phase 2: Composable Transform System
 
-- [ ] 7. **Design the transform type system.** Define a `Transform<Policy>` as a callable that maps atmospheric state to a 2D array `[wavelength × height]`:
+- [ ] 7. **Design the transform type system.** Define a `Transform<Policy>` as a callable that maps atmospheric state to a 3D array `[wavelength × height × column]`:
    ```cpp
    using TransformFunc = std::function<void(
        const Grid<Policy>& wavelength_grid,
@@ -68,10 +152,10 @@ All outputs are in SI units. Any data files (e.g., legacy NetCDF files with wave
        const Profile<Policy>& temperature,
        const Profile<Policy>& pressure,
        const Profile<Policy>& air_density,
-       Array2D<T>& output  // [wavelength × height]
+       Array3D<T>& output  // [wavelength × height × column]
    )>;
    ```
-   This is the fundamental signature for cross-sections, quantum yields, and spectral weights.
+   This is the fundamental signature for cross-sections, quantum yields, and spectral weights. The output includes the column dimension because temperature, pressure, and density vary per column, so the computed values differ per column.
 
 - [ ] 8. **Implement composable transform primitives.** Each returns a `TransformFunc` (or equivalent callable). These are the building blocks:
 
@@ -115,7 +199,7 @@ All outputs are in SI units. Any data files (e.g., legacy NetCDF files with wave
 
 - [ ] 13. **Implement photolysis rate calculator.** Port `src/photolysis_rates.F90`. The core operation is:
     $$J_i(z) = \sum_\lambda F(\lambda, z) \cdot \sigma_i(\lambda, z) \cdot \phi_i(\lambda, z) \cdot \Delta\lambda$$
-    This is a batched dot product per height layer per reaction — highly parallelizable across columns and reactions. The API takes a solved `RadiationField`, a list of `(cross_section_transform, quantum_yield_transform)` pairs, and returns a 2D array `[reaction × height × column]`.
+    This is a batched dot product per height layer per reaction — highly parallelizable across columns and reactions. The API takes a solved `RadiationField`, a list of `(cross_section_transform, quantum_yield_transform)` pairs, and returns an `Array3D [reaction × height × column]`.
 
 - [ ] 14. **Implement dose rate calculator.** Port `src/dose_rates.F90`. Similar structure: spectral irradiance × spectral weight → dose rate per height.
 
@@ -193,3 +277,4 @@ All outputs are in SI units. Any data files (e.g., legacy NetCDF files with wave
 | Solver order | Delta Eddington first | Simpler two-stream method; validates full pipeline before tackling DISORT's 3,700 lines |
 | Configuration | No config files in solver library | Clean separation of concerns; MUSICA handles all configuration mapping |
 | Units | SI only, no conversions | All inputs/outputs in SI units (m, rad, s, K, Pa); no unit conversion code in the library; callers and data pipelines are responsible for providing SI data |
+| MICM consistency | Align API conventions with MICM | Both TUV-x and MICM are MUSICA components; consistent syntax (`operator[]`, `ForEachRow`, `ColumnView`, `Function` factory, `ArrayPolicy` template pattern) reduces cognitive load for users working across both libraries. Diverge only when TUV-x requirements demand it (e.g., `Array1D` instead of `std::vector`) |

--- a/.github/prompts/plan-tuvXCppSolverRewrite.prompt.md
+++ b/.github/prompts/plan-tuvXCppSolverRewrite.prompt.md
@@ -22,6 +22,7 @@ All outputs are in SI units. Any data files (e.g., legacy NetCDF files with wave
 - [ ] 1. **Create new repository** (`tuv-x-cpp` or chosen name) with CMake build system (CMake 3.21+ to match MUSICA). Configure languages `CXX` with optional `CUDA`/`HIP`. Set up GitHub Actions CI with strict quality gates: >95% unit test coverage enforced on PRs, valgrind memcheck on all tests, multi-compiler matrix (GCC, Clang, MSVC, Intel, NVHPC) across Linux/macOS/Windows, clang-tidy static analysis as a PR gate, and auto-generated formatting PRs via clang-format. Enforce legible naming conventions (no cryptic abbreviations).
 
 - [ ] 2. **Migrate reusable C++ code from current repo.** Port the following already-complete implementations from `include/tuvx/` into the new repo's `include/` and `src/`:
+   - `Array1D<T>` — new implementation (see below), modeled after `Array2D`/`Array3D`
    - `Array2D<T>`, `Array3D<T>` — `include/tuvx/util/array2d.hpp`, `include/tuvx/util/array3d.hpp`
    - `Grid<ArrayPolicy>` — `include/tuvx/grid.hpp`
    - `Profile<ArrayPolicy>` — `include/tuvx/profile.hpp`
@@ -38,6 +39,7 @@ All outputs are in SI units. Any data files (e.g., legacy NetCDF files with wave
    - `DeviceArrayPolicy` — CUDA/HIP device memory; coalesced access patterns; same element access syntax via `__host__ __device__` accessors
    - Solver functions are templated on `ArrayPolicy` and written exactly once — no `#ifdef` branching, no runtime dispatch
    - All core types (`Grid`, `Profile`, `RadiatorState`, `RadiationField`, `TridiagonalMatrix`) are already templated on `ArrayPolicy` in the existing codebase; this pattern is preserved and extended
+   - **`Array1D<T>`**: Create a new 1D array type following the same pattern as `Array2D<T>` and `Array3D<T>`. This replaces all uses of `std::vector` in APIs that interact with `Grid`/`Profile`/policy-backed data, ensuring consistency when data is device-resident. `Array1D` must support the same `ArrayPolicy`-controlled memory allocation and access as the 2D/3D types. **No `std::vector` should appear in any function signature that also takes policy-backed types** — use `Array1D` instead
 
 
 ## Phase 1: Delta Eddington Solver
@@ -133,8 +135,8 @@ All outputs are in SI units. Any data files (e.g., legacy NetCDF files with wave
     ```cpp
     class DataReader {
         virtual Array2D<double> read_parameters(const std::string& variable_prefix) = 0;
-        virtual std::vector<double> read_wavelengths() = 0;
-        virtual std::vector<double> read_temperatures() = 0;  // optional
+        virtual Array1D<double> read_wavelengths() = 0;
+        virtual Array1D<double> read_temperatures() = 0;  // optional
     };
     ```
     Implement `NetCDFReader` using NetCDF-C (no Fortran dependency). This reads the existing ~160 `.nc` files unchanged. Additional readers (HDF5, CSV, binary) can be added later.
@@ -143,19 +145,21 @@ All outputs are in SI units. Any data files (e.g., legacy NetCDF files with wave
 
 - [ ] 20. **Define the top-level solver API.** This replaces the Fortran `core_t`. The API is purely programmatic — no config files:
     ```cpp
+    template<typename ArrayPolicy>
     class Solver {
         // Configure solver with template policy for CPU or GPU
         void solve(
-            const std::vector<Column>& columns,  // batch of atmospheric columns
-            const SolverOptions& options,          // solver type, surface albedo, etc.
-            RadiationField& radiation_field        // output
+            const AtmosphericState<ArrayPolicy>& state,
+            const RadiatorState<ArrayPolicy>& radiator_state,
+            RadiationField<ArrayPolicy>& radiation_field   // output
         );
     };
 
     // Full pipeline: solve radiation field then compute rates
+    template<typename ArrayPolicy>
     class PhotolysisCalculator {
-        void add_reaction(std::string name, TransformFunc cross_section, TransformFunc quantum_yield);
-        void calculate(const RadiationField& field, const AtmosphericState& state, RateOutput& output);
+        void add_reaction(std::string name, TransformFunc<ArrayPolicy> cross_section, TransformFunc<ArrayPolicy> quantum_yield);
+        void calculate(const RadiationField<ArrayPolicy>& field, const AtmosphericState<ArrayPolicy>& state, Array3D<typename ArrayPolicy::value_type>& rates);
     };
     ```
 

--- a/.github/prompts/plan-tuvXCppSolverRewrite.prompt.md
+++ b/.github/prompts/plan-tuvXCppSolverRewrite.prompt.md
@@ -144,7 +144,7 @@ This means solver functions never loop over columns explicitly — they express 
 
 ## Phase 2: Composable Transform System
 
-- [ ] 7. **Design the transform type system.** Define a `Transform<Policy>` as a callable that maps atmospheric state to a 3D array `[wavelength × height × column]`:
+- [ ] 7. **Design the transform type system.** Define `TransformFunc` as a callable that maps atmospheric state to a 3D output array `[wavelength × height × column]`:
    ```cpp
    using TransformFunc = std::function<void(
        const Grid<Policy>& wavelength_grid,
@@ -155,43 +155,56 @@ This means solver functions never loop over columns explicitly — they express 
        Array3D<T>& output  // [wavelength × height × column]
    )>;
    ```
-   This is the fundamental signature for cross-sections, quantum yields, and spectral weights. The output includes the column dimension because temperature, pressure, and density vary per column, so the computed values differ per column.
+   **`TransformFunc` is the open, user-facing API.** Any callable matching this signature is a valid transform — users can write raw lambdas, function objects, or free functions directly. No factory or wrapper is required:
+   ```cpp
+   // User-written transform — just a lambda matching the signature:
+   TransformFunc<Policy> my_cross_section = [coeff](const auto& wl_grid, const auto& alt_grid,
+       const auto& temperature, const auto& pressure, const auto& air_density, auto& output) {
+       // User's custom logic using ForEachRow, ColumnView, etc.
+   };
+   ```
+   The output includes the column dimension because temperature, pressure, and density vary per column, so the computed values differ per column.
 
-- [ ] 8. **Implement composable transform primitives.** Each returns a `TransformFunc` (or equivalent callable). These are the building blocks:
+- [ ] 8. **Implement convenience transform library.** Provide a library of pre-built factory functions that return `TransformFunc` callables. These are **convenience utilities built on the same public API a user would use** — they are not special internal constructs. Each factory captures its parameters and returns a lambda matching the `TransformFunc` signature. Users can use these off-the-shelf, compose them with combinators, or ignore them entirely and write raw lambdas:
 
-   | Primitive | Replaces | Description |
-   |-----------|----------|-------------|
-   | `from_data(reader, interpolator)` | Base `cross_section_t` | Load tabulated data via pluggable reader; interpolate to model grid |
-   | `temperature_interpolation(reader)` | `tint` | Linear interpolation between tabulated T-dependent data sets |
-   | `polynomial_scaling(coeffs, T_ref)` | CCl4, acetone, ClONO2 | $\sigma_0 \cdot P(T - T_{ref}, \lambda)$ |
-   | `exponential_scaling(coeffs, T_ref)` | CFC-11, RONO2, N2O5 | $\sigma_0 \cdot \exp(f(T, \lambda))$ |
-   | `linear_correction(slope_data)` | CH2O | $\sigma_0 + \beta \cdot \Delta T$ |
-   | `analytic(lambda_expr)` | Rayleigh, nitroxy compounds | User-supplied lambda for analytic formulas |
-   | `stern_volmer(phi0, k)` | CH2O quantum yield | Quenching: $1/(1/\phi_0 + k \cdot M)$ |
-   | `parameterized(type, params)` | Taylor/Burkholder/Harwood | Pluggable parameterization strategies |
+   | Factory function | Math | Useful for |
+   |-----------|------|------------------------|
+   | `from_data(reader, interpolator)` | Tabulated data → model grid interpolation | Base cross-sections, quantum yields |
+   | `temperature_interpolation(reader)` | $\sigma(\lambda,T) = \sigma_i + \frac{T-T_i}{T_{i+1}-T_i}(\sigma_{i+1}-\sigma_i)$ | T-dependent tint types |
+   | `polynomial_scaling(coeffs, T_ref)` | $\sigma_0 \cdot P(T - T_{ref}, \lambda)$ | CCl4, acetone, ClONO2, HCFC |
+   | `exponential_scaling(coeffs, T_ref)` | $\sigma_0 \cdot \exp(f(T, \lambda))$ | CFC-11, RONO2, N2O5, CHBr3 |
+   | `linear_correction(slope_data)` | $\sigma_0 + \beta \cdot \Delta T$ | CH2O |
+   | `stern_volmer(phi0, k)` | $\phi = 1/(1/\phi_0 + k \cdot M)$ | Quenching quantum yields |
+   | `parameterized(type, params)` | Taylor series, Burkholder, Harwood strategies | T-parameterized cross-sections |
+   | `wrap_analytic(f)` | Adapts a simple `f(λ)→double` or `f(λ,T)→double` into the full `TransformFunc` signature | Quick one-liner formulas (Rayleigh, etc.) |
 
-- [ ] 9. **Implement transform combinators.** These compose primitives:
+   `wrap_analytic` is a **signature adapter** — it takes a simple function of wavelength (and optionally temperature) and wraps it to handle grid iteration and column broadcasting internally. It is a convenience for simple formulas, not the primary way to create custom transforms.
+
+- [ ] 9. **Implement transform combinators.** These are higher-order functions that take one or more `TransformFunc` values and return a new `TransformFunc`. They work with **any** transform — library-provided or user-written:
 
    | Combinator | Description |
    |------------|-------------|
    | `in_region(lambda_min, lambda_max, transform)` | Apply transform only in a wavelength sub-range; zero outside |
-   | `compose(base, modifier)` | Apply modifier to base output (multiply, add) |
+   | `multiply(a, b)` | Run both transforms, multiply their outputs element-wise |
+   | `add(a, b)` | Run both transforms, add their outputs element-wise |
    | `piecewise({region1: t1, region2: t2, ...})` | Different transforms in different wavelength regions |
    | `clamp(transform, min, max)` | Clamp output values |
    | `override_band(band_name, value, transform)` | Replace values in named spectral bands (Lyman-alpha, Schumann-Runge) |
    | `scale(factor, transform)` | Multiply by constant factor |
 
-- [ ] 10. **Port existing cross-section algorithms as composed transforms.** For each of the 27 cross-section types in `src/cross_sections/`, express as a composition of primitives. Example for CCl4:
+   **Why combinators instead of sequential application?** A `TransformFunc` *writes* to the output array — it doesn't modify an existing value. Applying two transforms in sequence would just overwrite the first result with the second. Combinators like `multiply(a, b)` internally run both transforms (one into the output, one into a temporary), then combine the results element-wise. This is the only way to combine two independent computations.
+
+- [ ] 10. **Port existing cross-section algorithms as composed transforms.** For each of the 27 cross-section types in `src/cross_sections/`, express as a library factory, a composition of factories via combinators, or a direct user-written `TransformFunc` lambda. Example for CCl4:
     ```cpp
-    auto ccl4_xs = compose(
+    auto ccl4_xs = multiply(
         from_data(netcdf_reader("CCl4.nc"), conserving_interpolator()),
         in_region(194e-9, 250e-9,
             polynomial_scaling({b0, b1, b2, b3, b4}, 295.0))
     );
     ```
-    For complex cases like O3 (4 regions, refraction correction) or H2O2 (blended polynomials via Boltzmann $\chi$), use `piecewise()` and `analytic()` with custom lambdas.
+    For complex cases like O3 (4 regions, refraction correction) or H2O2 (blended polynomials via Boltzmann $\chi$), use `piecewise()` with a mix of library factories and user-written lambdas.
 
-- [ ] 11. **Port quantum yield algorithms** (~20 types in `src/quantum_yields/`) using the same primitive/combinator system. Most reuse the same primitives; `stern_volmer`, `analytic`, and `temperature_interpolation` cover the majority.
+- [ ] 11. **Port quantum yield algorithms** (~20 types in `src/quantum_yields/`) using the same library factories, combinators, and/or user-written lambdas. Most reuse existing factories; `stern_volmer`, `wrap_analytic`, and `temperature_interpolation` cover the majority.
 
 - [ ] 12. **Port spectral weight algorithms** (~12 types in `src/spectral_weights/`) — these are simpler wavelength-only transforms (`gaussian`, `notch_filter`, `exponential_decay`, etc.).
 
@@ -259,7 +272,7 @@ This means solver functions never loop over columns explicitly — they express 
 
 ## Verification
 
-- **Unit tests** (GTest): Each transform primitive, combinator, interpolator, data reader, and solver step gets individual tests. Migrate existing C++ tests from the current repo.
+- **Unit tests** (GTest): Each transform factory function, combinator, interpolator, data reader, and solver step gets individual tests. Include tests of user-written `TransformFunc` lambdas to verify the API is fully open. Migrate existing C++ tests from the current repo.
 - **Regression tests**: Pre-compute reference outputs from the current Fortran solver for several standard configurations (`examples/tuv_5_4.json`, `examples/ts1_tsmlt.json`) and store as binary fixtures. The new C++ solver must match within floating-point tolerance.
 - **Cross-validation of transforms**: For each of the 27 cross-section types and 20 quantum yield types, compare the new composed-transform output against Fortran reference values at multiple temperature/pressure points.
 - **Performance benchmarks**: Google Benchmark tests for multi-column solver throughput (1, 10, 100, 1000 columns) on CPU. CUDA/HIP benchmarks once GPU policy is implemented.
@@ -270,7 +283,7 @@ This means solver functions never loop over columns explicitly — they express 
 | Decision | Choice | Rationale |
 |----------|--------|-----------|
 | Language | C++ | Builds on existing partial port; native MUSICA integration; standard HPC ecosystem |
-| Transform API | Lambda/functional composables | Removes ~3,000 lines of factory/config dispatch code; composable and testable; config layer lives in MUSICA |
+| Transform API | Open callable signature (`TransformFunc`) | Any lambda/callable matching the signature is a valid transform; convenience factory library covers common patterns; combinators compose any transforms; config layer lives in MUSICA |
 | GPU portability | Template policies | Lighter weight than Kokkos/SYCL; consistent with existing codebase; can wrap Kokkos later if needed |
 | Migration strategy | New standalone repo | Clean separation; old Fortran repo stays as reference/validation; MUSICA switches dependency when ready |
 | Data readers | Pluggable interface, NetCDF-C default | Future-proofs against format changes; no Fortran dependency |


### PR DESCRIPTION
This PR adds a Copilot-generated plan for Copilot to port TUV-x to C++.

I made some choices along the way that can be modified as needed (e.g., new vs. existing repo; C++ vs Rust; etc)