### PR TITLE
Phase 2 prerequisite: bulk operations API for Array2D and Array3D

### DIFF
--- a/include/tuvx/util/array1d.hpp
+++ b/include/tuvx/util/array1d.hpp
@@ -13,6 +13,8 @@ namespace tuvx
   class Array1D
   {
    public:
+    using value_type = T;
+
     Array1D() = default;
 
     /// @brief Construct an array of the given size.
@@ -63,11 +65,11 @@ namespace tuvx
       return data_.end();
     }
 
-    T* Data()
+    T *Data()
     {
       return data_.data();
     }
-    const T* Data() const
+    const T *Data() const
     {
       return data_.data();
     }

--- a/include/tuvx/util/array2d.hpp
+++ b/include/tuvx/util/array2d.hpp
@@ -2,22 +2,124 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include <cassert>
 #include <cstddef>
+#include <functional>
 #include <vector>
 
 namespace tuvx
 {
 
-  /// @brief 2D array with row-major storage.
+  /// @brief 2D array with row-major storage [rows × columns].
+  ///
+  /// Dimensions are referred to as "rows" (dim1) and "columns" (dim2).
+  /// Bulk operations access data through column views rather than direct
+  /// element indexing so that the layout can be changed by policy subclasses
+  /// without modifying algorithm code.
   template<typename T = double>
   class Array2D
   {
    public:
+    using value_type = T;
+
+    // -------------------------------------------------------------------------
+    // Column views — lightweight non-owning proxies into one column's data.
+    //
+    // Views hold a non-owning pointer to the parent array; they are only valid
+    // for the lifetime of that array.
+
+    /// @brief Mutable view of one column across all rows.
+    class ColumnView
+    {
+     public:
+      ColumnView(Array2D<T> *arr, std::size_t col)
+          : arr_(arr),
+            col_(col)
+      {
+      }
+      T &operator[](std::size_t row) { return (*arr_)(row, col_); }
+      const T &operator[](std::size_t row) const { return (*arr_)(row, col_); }
+
+     private:
+      Array2D<T> *arr_ = nullptr;
+      std::size_t col_ = 0;
+    };
+
+    /// @brief Read-only view of one column across all rows.
+    class ConstColumnView
+    {
+     public:
+      ConstColumnView(const Array2D<T> *arr, std::size_t col)
+          : arr_(arr),
+            col_(col)
+      {
+      }
+      const T &operator[](std::size_t row) const { return (*arr_)(row, col_); }
+
+     private:
+      const Array2D<T> *arr_ = nullptr;
+      std::size_t col_ = 0;
+    };
+
+    /// @brief Temporary per-row scalar storage; participates in ForEachRow like a column view.
+    class RowVariable
+    {
+     public:
+      explicit RowVariable(std::size_t n_rows)
+          : data_(n_rows)
+      {
+      }
+      T &operator[](std::size_t row) { return data_[row]; }
+      const T &operator[](std::size_t row) const { return data_[row]; }
+
+     private:
+      std::vector<T> data_{};
+    };
+
+    // -------------------------------------------------------------------------
+    // Function — reusable, policy-compiled operation over this array type.
+    //
+    // For the CPU host policy, Function is a lightweight wrapper: it captures
+    // the callable and re-applies it on demand. GPU policies pre-compile
+    // kernels at construction time using the prototype's dimension metadata.
+    //
+    // Usage:
+    //   auto f = Array2D<double>::Function(
+    //       [](auto& arr) { arr.ForEachRow(...); },
+    //       prototype_array);
+    //   f(array_a);   // apply to any compatible array
+    //   f(array_b);
+
+    /// @brief Reusable policy-compiled operation.
+    class Function
+    {
+     public:
+      /// @brief Construct a reusable function from a callable and a prototype array.
+      /// @param f          Callable that operates on an Array2D via ForEachRow/ColumnView.
+      /// @param prototype  Prototype array (reserved for GPU policy pre-compilation).
+      template<typename F>
+      Function(F f, const Array2D & /*prototype*/)
+          : f_(std::move(f))
+      {
+      }
+
+      /// @brief Apply the compiled function to an array.
+      void operator()(Array2D &arr) const
+      {
+        f_(arr);
+      }
+
+     private:
+      std::function<void(Array2D<T> &)> f_;
+    };
+
+    // -------------------------------------------------------------------------
+
     Array2D() = default;
 
     /// @brief Construct an array with the given dimensions.
-    /// @param dim1 Size of the first dimension (rows).
-    /// @param dim2 Size of the second dimension (columns).
+    /// @param dim1 Number of rows.
+    /// @param dim2 Number of columns.
     Array2D(std::size_t dim1, std::size_t dim2)
         : dim1_(dim1),
           dim2_(dim2),
@@ -35,16 +137,66 @@ namespace tuvx
       return data_[(i * dim2_) + j];
     }
 
-    /// @brief Size of the first dimension (rows).
+    /// @brief Number of rows.
     [[nodiscard]] std::size_t Size1() const
     {
       return dim1_;
     }
-    /// @brief Size of the second dimension (columns).
+
+    /// @brief Number of columns.
     [[nodiscard]] std::size_t Size2() const
     {
       return dim2_;
     }
+
+    // -------------------------------------------------------------------------
+    // Bulk operations API
+
+    /// @brief Return a mutable column view for bulk iteration.
+    /// @param col Column index [0, Size2()).
+    ColumnView GetColumnView(std::size_t col)
+    {
+      assert(col < dim2_);
+      return ColumnView(this, col);
+    }
+
+    /// @brief Return a read-only column view for bulk iteration.
+    /// @param col Column index [0, Size2()).
+    ConstColumnView GetConstColumnView(std::size_t col) const
+    {
+      assert(col < dim2_);
+      return ConstColumnView(this, col);
+    }
+
+    /// @brief Return temporary per-row storage for intermediate calculations.
+    RowVariable GetRowVariable() const
+    {
+      return RowVariable(dim1_);
+    }
+
+    /// @brief Iterate over all rows, invoking @p f with one element per view per row.
+    ///
+    /// The lambda receives references to the corresponding element of each
+    /// supplied view at each row index.  Views may be ColumnView, ConstColumnView,
+    /// RowVariable, Array1D, or any object supporting operator[](std::size_t).
+    ///
+    /// Example (scale column 0 into column 1):
+    /// @code
+    ///   arr.ForEachRow(
+    ///       [](const double& a, double& b) { b = a * 2.0; },
+    ///       arr.GetConstColumnView(0),
+    ///       arr.GetColumnView(1));
+    /// @endcode
+    template<typename Func, typename... Views>
+    void ForEachRow(Func &&f, Views &&...views)  // NOLINT(cppcoreguidelines-missing-std-forward)
+    {
+      for (std::size_t i = 0; i < dim1_; ++i)
+      {
+        std::invoke(std::forward<Func>(f), views[i]...);
+      }
+    }
+
+    // -------------------------------------------------------------------------
 
     typename std::vector<T>::iterator begin()
     {
@@ -63,11 +215,11 @@ namespace tuvx
       return data_.end();
     }
 
-    T* Data()
+    T *Data()
     {
       return data_.data();
     }
-    const T* Data() const
+    const T *Data() const
     {
       return data_.data();
     }
@@ -85,6 +237,6 @@ namespace tuvx
     std::size_t dim1_ = 0;
     std::size_t dim2_ = 0;
     std::vector<T> data_{};
-
   };
+
 }  // namespace tuvx

--- a/include/tuvx/util/array3d.hpp
+++ b/include/tuvx/util/array3d.hpp
@@ -2,23 +2,132 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include <cassert>
 #include <cstddef>
+#include <functional>
 #include <vector>
 
 namespace tuvx
 {
 
-  /// @brief 3D array with row-major storage.
+  /// @brief 3D array with row-major storage [dim1 × dim2 × columns].
+  ///
+  /// The column dimension is always the last (innermost) dimension.
+  /// Bulk operations access data through column views rather than direct
+  /// element indexing so that the layout can be changed by policy subclasses
+  /// without modifying algorithm code.
+  ///
+  /// For transforms, the typical layout is [wavelength × height × column].
   template<typename T = double>
   class Array3D
   {
    public:
+    using value_type = T;
+
+    // -------------------------------------------------------------------------
+    // Column views — lightweight non-owning proxies into one column's data.
+    //
+    // Views hold a non-owning pointer to the parent array; they are only valid
+    // for the lifetime of that array.
+
+    /// @brief Mutable view of one column across all (dim1, dim2) positions.
+    class ColumnView
+    {
+     public:
+      ColumnView(Array3D<T> *arr, std::size_t col)
+          : arr_(arr),
+            col_(col)
+      {
+      }
+      T &operator()(std::size_t i, std::size_t j) { return (*arr_)(i, j, col_); }
+      const T &operator()(std::size_t i, std::size_t j) const { return (*arr_)(i, j, col_); }
+
+     private:
+      Array3D<T> *arr_ = nullptr;
+      std::size_t col_ = 0;
+    };
+
+    /// @brief Read-only view of one column across all (dim1, dim2) positions.
+    class ConstColumnView
+    {
+     public:
+      ConstColumnView(const Array3D<T> *arr, std::size_t col)
+          : arr_(arr),
+            col_(col)
+      {
+      }
+      const T &operator()(std::size_t i, std::size_t j) const { return (*arr_)(i, j, col_); }
+
+     private:
+      const Array3D<T> *arr_ = nullptr;
+      std::size_t col_ = 0;
+    };
+
+    /// @brief Temporary per-(dim1,dim2)-pair scalar storage; participates in ForEachRow like a column view.
+    class RowVariable
+    {
+     public:
+      RowVariable(std::size_t dim1, std::size_t dim2)
+          : data_((dim1 * dim2)),
+            dim2_(dim2)
+      {
+      }
+      T &operator()(std::size_t i, std::size_t j) { return data_[(i * dim2_) + j]; }
+      const T &operator()(std::size_t i, std::size_t j) const { return data_[(i * dim2_) + j]; }
+
+     private:
+      std::vector<T> data_{};
+      std::size_t dim2_ = 0;
+    };
+
+    // -------------------------------------------------------------------------
+    // Function — reusable, policy-compiled operation over this array type.
+    //
+    // For the CPU host policy, Function is a lightweight wrapper: it captures
+    // the callable and re-applies it on demand. GPU policies pre-compile
+    // kernels at construction time using the prototype's dimension metadata.
+    //
+    // Usage:
+    //   auto f = Array3D<double>::Function(
+    //       [](auto& arr) {
+    //           auto tmp = arr.GetRowVariable();
+    //           arr.ForEachRow(..., arr.GetConstColumnView(0), tmp);
+    //           arr.ForEachRow(..., tmp, arr.GetColumnView(1));
+    //       },
+    //       prototype_array);
+    //   f(array_a);   // apply to any compatible array
+
+    /// @brief Reusable policy-compiled operation.
+    class Function
+    {
+     public:
+      /// @brief Construct a reusable function from a callable and a prototype array.
+      /// @param f          Callable that operates on an Array3D via ForEachRow/ColumnView.
+      /// @param prototype  Prototype array (reserved for GPU policy pre-compilation).
+      template<typename F>
+      Function(F f, const Array3D & /*prototype*/)
+          : f_(std::move(f))
+      {
+      }
+
+      /// @brief Apply the compiled function to an array.
+      void operator()(Array3D &arr) const
+      {
+        f_(arr);
+      }
+
+     private:
+      std::function<void(Array3D<T> &)> f_;
+    };
+
+    // -------------------------------------------------------------------------
+
     Array3D() = default;
 
     /// @brief Construct an array with the given dimensions.
     /// @param dim1 Size of the first dimension.
     /// @param dim2 Size of the second dimension.
-    /// @param dim3 Size of the third dimension.
+    /// @param dim3 Size of the third (column) dimension.
     Array3D(std::size_t dim1, std::size_t dim2, std::size_t dim3)
         : dim1_(dim1),
           dim2_(dim2),
@@ -49,11 +158,74 @@ namespace tuvx
       return dim2_;
     }
 
-    /// @brief Size of the third dimension.
+    /// @brief Size of the third (column) dimension.
     [[nodiscard]] std::size_t Size3() const
     {
       return dim3_;
     }
+
+    // -------------------------------------------------------------------------
+    // Bulk operations API
+
+    /// @brief Return a mutable column view for bulk iteration.
+    /// @param col Column index [0, Size3()).
+    ColumnView GetColumnView(std::size_t col)
+    {
+      assert(col < dim3_);
+      return ColumnView(this, col);
+    }
+
+    /// @brief Return a read-only column view for bulk iteration.
+    /// @param col Column index [0, Size3()).
+    ConstColumnView GetConstColumnView(std::size_t col) const
+    {
+      assert(col < dim3_);
+      return ConstColumnView(this, col);
+    }
+
+    /// @brief Return temporary per-(dim1,dim2)-pair storage for intermediate calculations.
+    RowVariable GetRowVariable() const
+    {
+      return RowVariable(dim1_, dim2_);
+    }
+
+    /// @brief Iterate over all (dim1, dim2) pairs, invoking @p f with one element per view per pair.
+    ///
+    /// The lambda receives references to the corresponding element of each
+    /// supplied view at each (i, j) index pair.  Views may be ColumnView,
+    /// ConstColumnView, RowVariable, Array2D, or any object supporting
+    /// operator()(std::size_t, std::size_t).
+    ///
+    /// Example (scale column 0 into column 1 of a weights array):
+    /// @code
+    ///   weights.ForEachRow(
+    ///       [](const double& a, double& b) { b = a * 2.0; },
+    ///       weights.GetConstColumnView(0),
+    ///       weights.GetColumnView(1));
+    /// @endcode
+    ///
+    /// Passing an Array2D<T> as a view broadcasts it across both (i, j) dimensions
+    /// since Array2D already provides operator()(std::size_t, std::size_t):
+    /// @code
+    ///   // temperature is Array2D<double>[height × col]; use as view in a 3D ForEachRow
+    ///   weights.ForEachRow(
+    ///       [](double& w, const double& t) { w *= factor(t); },
+    ///       weights.GetColumnView(col),
+    ///       temperature);
+    /// @endcode
+    template<typename Func, typename... Views>
+    void ForEachRow(Func &&f, Views &&...views)  // NOLINT(cppcoreguidelines-missing-std-forward)
+    {
+      for (std::size_t i = 0; i < dim1_; ++i)
+      {
+        for (std::size_t j = 0; j < dim2_; ++j)
+        {
+          std::invoke(std::forward<Func>(f), views(i, j)...);
+        }
+      }
+    }
+
+    // -------------------------------------------------------------------------
 
     typename std::vector<T>::iterator begin()
     {
@@ -75,11 +247,11 @@ namespace tuvx
       return data_.end();
     }
 
-    T* Data()
+    T *Data()
     {
       return data_.data();
     }
-    const T* Data() const
+    const T *Data() const
     {
       return data_.data();
     }
@@ -98,7 +270,6 @@ namespace tuvx
     std::size_t dim2_ = 0;
     std::size_t dim3_ = 0;
     std::vector<T> data_{};
-
   };
 
 }  // namespace tuvx

--- a/test/unit/util/array2d.cpp
+++ b/test/unit/util/array2d.cpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 #include <tuvx/util/array2d.hpp>
 
+#include <tuvx/util/array1d.hpp>
+
 #include <gtest/gtest.h>
 
 TEST(Array2D, Constructor)
@@ -22,4 +24,179 @@ TEST(Array2D, Constructor)
   EXPECT_EQ(a(1, 0), 45);
   EXPECT_EQ(a(1, 1), 14);
   EXPECT_EQ(a(1, 2), 100);
+}
+
+TEST(Array2D, ValueType)
+{
+  static_assert(std::is_same_v<tuvx::Array2D<double>::value_type, double>);
+  static_assert(std::is_same_v<tuvx::Array2D<int>::value_type, int>);
+}
+
+// [rows=3, cols=2]:
+//   col 0: rows 0,1,2  -> values 1,3,5
+//   col 1: rows 0,1,2  -> values 2,4,6
+TEST(Array2D, ColumnView)
+{
+  tuvx::Array2D<double> a(3, 2);
+  a(0, 0) = 1.0;
+  a(0, 1) = 2.0;
+  a(1, 0) = 3.0;
+  a(1, 1) = 4.0;
+  a(2, 0) = 5.0;
+  a(2, 1) = 6.0;
+
+  auto col0 = a.GetColumnView(0);
+  EXPECT_DOUBLE_EQ(col0[0], 1.0);
+  EXPECT_DOUBLE_EQ(col0[1], 3.0);
+  EXPECT_DOUBLE_EQ(col0[2], 5.0);
+
+  auto col1 = a.GetColumnView(1);
+  EXPECT_DOUBLE_EQ(col1[0], 2.0);
+  EXPECT_DOUBLE_EQ(col1[1], 4.0);
+  EXPECT_DOUBLE_EQ(col1[2], 6.0);
+
+  // Mutate through view
+  col0[1] = 99.0;
+  EXPECT_DOUBLE_EQ(a(1, 0), 99.0);
+}
+
+TEST(Array2D, ConstColumnView)
+{
+  tuvx::Array2D<double> a(3, 2);
+  a(0, 0) = 1.0;
+  a(1, 0) = 2.0;
+  a(2, 0) = 3.0;
+
+  const auto &ca = a;
+  auto cv = ca.GetConstColumnView(0);
+  EXPECT_DOUBLE_EQ(cv[0], 1.0);
+  EXPECT_DOUBLE_EQ(cv[1], 2.0);
+  EXPECT_DOUBLE_EQ(cv[2], 3.0);
+}
+
+// RowVariable stores per-row temporaries, same interface as a column view.
+TEST(Array2D, RowVariable)
+{
+  tuvx::Array2D<double> a(3, 2);
+  auto tmp = a.GetRowVariable();
+
+  tmp[0] = 10.0;
+  tmp[1] = 20.0;
+  tmp[2] = 30.0;
+
+  EXPECT_DOUBLE_EQ(tmp[0], 10.0);
+  EXPECT_DOUBLE_EQ(tmp[1], 20.0);
+  EXPECT_DOUBLE_EQ(tmp[2], 30.0);
+}
+
+// ForEachRow: copy column 0 into column 1, scaling by 2.
+TEST(Array2D, ForEachRowScale)
+{
+  tuvx::Array2D<double> a(4, 2);
+  a(0, 0) = 1.0;
+  a(1, 0) = 2.0;
+  a(2, 0) = 3.0;
+  a(3, 0) = 4.0;
+
+  a.ForEachRow(
+      [](const double &src, double &dst) { dst = src * 2.0; },
+      a.GetConstColumnView(0),
+      a.GetColumnView(1));
+
+  EXPECT_DOUBLE_EQ(a(0, 1), 2.0);
+  EXPECT_DOUBLE_EQ(a(1, 1), 4.0);
+  EXPECT_DOUBLE_EQ(a(2, 1), 6.0);
+  EXPECT_DOUBLE_EQ(a(3, 1), 8.0);
+  // Source column unchanged
+  EXPECT_DOUBLE_EQ(a(0, 0), 1.0);
+  EXPECT_DOUBLE_EQ(a(1, 0), 2.0);
+}
+
+// ForEachRow with RowVariable as intermediate storage.
+TEST(Array2D, ForEachRowWithRowVariable)
+{
+  tuvx::Array2D<double> a(3, 3);
+  a(0, 0) = 1.0;
+  a(1, 0) = 2.0;
+  a(2, 0) = 3.0;
+  a(0, 1) = 10.0;
+  a(1, 1) = 20.0;
+  a(2, 1) = 30.0;
+
+  // tmp = col0 + col1
+  auto tmp = a.GetRowVariable();
+  a.ForEachRow(
+      [](const double &a0, const double &a1, double &t) { t = a0 + a1; },
+      a.GetConstColumnView(0),
+      a.GetConstColumnView(1),
+      tmp);
+
+  // col2 = tmp * 2
+  a.ForEachRow(
+      [](const double &t, double &out) { out = t * 2.0; },
+      tmp,
+      a.GetColumnView(2));
+
+  EXPECT_DOUBLE_EQ(a(0, 2), 22.0);
+  EXPECT_DOUBLE_EQ(a(1, 2), 44.0);
+  EXPECT_DOUBLE_EQ(a(2, 2), 66.0);
+}
+
+// Function: build a reusable operation and apply it to two arrays.
+TEST(Array2D, Function)
+{
+  tuvx::Array2D<double> proto(3, 2);
+
+  // op: col1 = col0 * 3
+  auto func = tuvx::Array2D<double>::Function(
+      [](auto &arr) {
+        arr.ForEachRow(
+            [](const double &src, double &dst) { dst = src * 3.0; },
+            arr.GetConstColumnView(0),
+            arr.GetColumnView(1));
+      },
+      proto);
+
+  tuvx::Array2D<double> a(3, 2);
+  a(0, 0) = 1.0;
+  a(1, 0) = 2.0;
+  a(2, 0) = 3.0;
+  func(a);
+  EXPECT_DOUBLE_EQ(a(0, 1), 3.0);
+  EXPECT_DOUBLE_EQ(a(1, 1), 6.0);
+  EXPECT_DOUBLE_EQ(a(2, 1), 9.0);
+
+  tuvx::Array2D<double> b(3, 2);
+  b(0, 0) = 4.0;
+  b(1, 0) = 5.0;
+  b(2, 0) = 6.0;
+  func(b);
+  EXPECT_DOUBLE_EQ(b(0, 1), 12.0);
+  EXPECT_DOUBLE_EQ(b(1, 1), 15.0);
+  EXPECT_DOUBLE_EQ(b(2, 1), 18.0);
+}
+
+// ForEachRow with Array1D as a view (uses operator[](size_t)).
+TEST(Array2D, ForEachRowWithArray1D)
+{
+  tuvx::Array2D<double> a(3, 2);
+
+  tuvx::Array1D<double> offsets(3);
+  offsets[0] = 100.0;
+  offsets[1] = 200.0;
+  offsets[2] = 300.0;
+
+  a(0, 0) = 1.0;
+  a(1, 0) = 2.0;
+  a(2, 0) = 3.0;
+
+  a.ForEachRow(
+      [](const double &src, const double &offset, double &dst) { dst = src + offset; },
+      a.GetConstColumnView(0),
+      offsets,
+      a.GetColumnView(1));
+
+  EXPECT_DOUBLE_EQ(a(0, 1), 101.0);
+  EXPECT_DOUBLE_EQ(a(1, 1), 202.0);
+  EXPECT_DOUBLE_EQ(a(2, 1), 303.0);
 }

--- a/test/unit/util/array3d.cpp
+++ b/test/unit/util/array3d.cpp
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 #include <tuvx/util/array3d.hpp>
 
+#include <tuvx/util/array2d.hpp>
+
 #include <gtest/gtest.h>
 
 TEST(Array3D, Constructor)
@@ -41,4 +43,186 @@ TEST(Array3D, Constructor)
   EXPECT_EQ(a(1, 2, 1), 31);
   EXPECT_EQ(a(1, 2, 2), 32);
   EXPECT_EQ(a(1, 2, 3), 100);
+}
+
+TEST(Array3D, ValueType)
+{
+  static_assert(std::is_same_v<tuvx::Array3D<double>::value_type, double>);
+  static_assert(std::is_same_v<tuvx::Array3D<float>::value_type, float>);
+}
+
+// Layout [2 × 3 × 2] (wl=2, height=3, col=2)
+//   col 0: a(i,j,0), col 1: a(i,j,1)
+TEST(Array3D, ColumnView)
+{
+  tuvx::Array3D<double> a(2, 3, 2);
+  // Fill col 0 with sequential values 1..6, col 1 with 10..15
+  int c0 = 1;
+  int c1 = 10;
+  for (std::size_t i = 0; i < 2; ++i)
+  {
+    for (std::size_t j = 0; j < 3; ++j)
+    {
+      a(i, j, 0) = static_cast<double>(c0++);
+      a(i, j, 1) = static_cast<double>(c1++);
+    }
+  }
+
+  auto col0 = a.GetColumnView(0);
+  EXPECT_DOUBLE_EQ(col0(0, 0), 1.0);
+  EXPECT_DOUBLE_EQ(col0(0, 1), 2.0);
+  EXPECT_DOUBLE_EQ(col0(0, 2), 3.0);
+  EXPECT_DOUBLE_EQ(col0(1, 0), 4.0);
+  EXPECT_DOUBLE_EQ(col0(1, 1), 5.0);
+  EXPECT_DOUBLE_EQ(col0(1, 2), 6.0);
+
+  // Mutate through view
+  col0(1, 0) = 99.0;
+  EXPECT_DOUBLE_EQ(a(1, 0, 0), 99.0);
+
+  const auto &ca = a;
+  auto cc = ca.GetConstColumnView(1);
+  EXPECT_DOUBLE_EQ(cc(0, 0), 10.0);
+  EXPECT_DOUBLE_EQ(cc(1, 2), 15.0);
+}
+
+TEST(Array3D, RowVariable)
+{
+  tuvx::Array3D<double> a(2, 3, 1);
+  auto tmp = a.GetRowVariable();
+
+  tmp(0, 0) = 1.0;
+  tmp(0, 1) = 2.0;
+  tmp(0, 2) = 3.0;
+  tmp(1, 0) = 4.0;
+  tmp(1, 1) = 5.0;
+  tmp(1, 2) = 6.0;
+
+  EXPECT_DOUBLE_EQ(tmp(0, 0), 1.0);
+  EXPECT_DOUBLE_EQ(tmp(1, 2), 6.0);
+}
+
+// ForEachRow: col 1 = col 0 * 2 across all (i, j) positions.
+TEST(Array3D, ForEachRowScale)
+{
+  tuvx::Array3D<double> a(2, 3, 2);
+  for (std::size_t i = 0; i < 2; ++i)
+  {
+    for (std::size_t j = 0; j < 3; ++j)
+    {
+      a(i, j, 0) = static_cast<double>((i * 3) + j + 1);
+    }
+  }
+
+  a.ForEachRow(
+      [](const double &src, double &dst) { dst = src * 2.0; },
+      a.GetConstColumnView(0),
+      a.GetColumnView(1));
+
+  for (std::size_t i = 0; i < 2; ++i)
+  {
+    for (std::size_t j = 0; j < 3; ++j)
+    {
+      EXPECT_DOUBLE_EQ(a(i, j, 1), a(i, j, 0) * 2.0);
+    }
+  }
+}
+
+// ForEachRow with RowVariable as intermediate.
+TEST(Array3D, ForEachRowWithRowVariable)
+{
+  tuvx::Array3D<double> a(2, 2, 3);  // [dim1=2, dim2=2, col=3]
+  for (std::size_t i = 0; i < 2; ++i)
+  {
+    for (std::size_t j = 0; j < 2; ++j)
+    {
+      a(i, j, 0) = static_cast<double>((i * 2) + j + 1);    // 1,2,3,4
+      a(i, j, 1) = static_cast<double>(((i * 2) + j) * 10);  // 0,10,20,30
+    }
+  }
+
+  auto tmp = a.GetRowVariable();
+  a.ForEachRow(
+      [](const double &x, const double &y, double &t) { t = x + y; },
+      a.GetConstColumnView(0),
+      a.GetConstColumnView(1),
+      tmp);
+
+  a.ForEachRow(
+      [](const double &t, double &out) { out = t * 2.0; },
+      tmp,
+      a.GetColumnView(2));
+
+  EXPECT_DOUBLE_EQ(a(0, 0, 2), 2.0);   // (1 + 0) * 2
+  EXPECT_DOUBLE_EQ(a(0, 1, 2), 24.0);  // (2 + 10) * 2
+  EXPECT_DOUBLE_EQ(a(1, 0, 2), 46.0);  // (3 + 20) * 2
+  EXPECT_DOUBLE_EQ(a(1, 1, 2), 68.0);  // (4 + 30) * 2
+}
+
+// Function: build a reusable operation and apply it to two arrays.
+TEST(Array3D, Function)
+{
+  tuvx::Array3D<double> proto(2, 2, 3);
+
+  auto func = tuvx::Array3D<double>::Function(
+      [](auto &arr) {
+        arr.ForEachRow(
+            [](const double &src, double &dst) { dst = src * 5.0; },
+            arr.GetConstColumnView(0),
+            arr.GetColumnView(1));
+      },
+      proto);
+
+  tuvx::Array3D<double> a(2, 2, 3);
+  a(0, 0, 0) = 1.0;
+  a(0, 1, 0) = 2.0;
+  a(1, 0, 0) = 3.0;
+  a(1, 1, 0) = 4.0;
+  func(a);
+  EXPECT_DOUBLE_EQ(a(0, 0, 1), 5.0);
+  EXPECT_DOUBLE_EQ(a(0, 1, 1), 10.0);
+  EXPECT_DOUBLE_EQ(a(1, 0, 1), 15.0);
+  EXPECT_DOUBLE_EQ(a(1, 1, 1), 20.0);
+
+  tuvx::Array3D<double> b(2, 2, 3);
+  b(0, 0, 0) = 10.0;
+  b(0, 1, 0) = 20.0;
+  b(1, 0, 0) = 30.0;
+  b(1, 1, 0) = 40.0;
+  func(b);
+  EXPECT_DOUBLE_EQ(b(0, 0, 1), 50.0);
+  EXPECT_DOUBLE_EQ(b(1, 1, 1), 200.0);
+}
+
+// ForEachRow with Array2D as view (broadcasts operator()(i, j) naturally).
+TEST(Array3D, ForEachRowWithArray2D)
+{
+  // weights [wl=2, z=3, col=2], temperature [wl=2, z=3]
+  // (temperature is constant across columns in this test — treat it as a 2D table)
+  tuvx::Array3D<double> weights(2, 3, 2);
+  tuvx::Array2D<double> temp_table(2, 3);  // [wl × z] — no column dim
+
+  for (std::size_t i = 0; i < 2; ++i)
+  {
+    for (std::size_t j = 0; j < 3; ++j)
+    {
+      weights(i, j, 0) = 1.0;
+      temp_table(i, j) = static_cast<double>((i * 3) + j + 1);  // 1..6
+    }
+  }
+
+  // col 1 = col 0 * temp_table(i, j)
+  weights.ForEachRow(
+      [](const double &w, const double &t, double &out) { out = w * t; },
+      weights.GetConstColumnView(0),
+      temp_table,
+      weights.GetColumnView(1));
+
+  for (std::size_t i = 0; i < 2; ++i)
+  {
+    for (std::size_t j = 0; j < 3; ++j)
+    {
+      EXPECT_DOUBLE_EQ(weights(i, j, 1), temp_table(i, j));
+    }
+  }
 }


### PR DESCRIPTION
This is in preparation for #177 

## Summary

- Adds `value_type` typedef to `Array1D`, `Array2D`, and `Array3D`
- Adds `ColumnView` / `ConstColumnView` (non-owning pointer-based views) to `Array2D` and `Array3D`
- Adds `RowVariable` (per-row temporary storage that participates in `ForEachRow` like a column view)
- Adds `ForEachRow` variadic template: iterates rows (2D) or (dim1,dim2) pairs (3D), calling the lambda with one element per view per position
- Adds `Function` nested class for reusable policy-compiled operations (CPU: `std::function` wrapper; GPU policies can pre-compile kernels at construction time)
- Passing `Array1D` to `Array2D::ForEachRow` and `Array2D` to `Array3D::ForEachRow` both work via duck typing on `operator[]` / `operator()`

## Test plan

- [ ] New tests in `test/unit/util/array2d.cpp`: `ColumnView`, `ConstColumnView`, `RowVariable`, `ForEachRow` (scale, intermediate `RowVariable`, `Array1D` as view), `Function`
- [ ] New tests in `test/unit/util/array3d.cpp`: same coverage plus `Array2D` as broadcast view in `ForEachRow`
- [ ] All 11 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)