### PR TITLE
Modernize host-only utility loops (std::ranges / avoid std::endl)

### DIFF
--- a/include/tuvx/linear_algebra/linear_algebra.inl
+++ b/include/tuvx/linear_algebra/linear_algebra.inl
@@ -58,10 +58,7 @@ namespace tuvx
   {
     std::mt19937 random_device(seed);
     std::normal_distribution<double> distribution(5.0, 1.0);
-    for (std::size_t i = 0; i < x.Size(); i++)
-    {
-      x[i] = static_cast<T>(distribution(random_device));
-    }
+    std::ranges::generate(x, [&]() { return static_cast<T>(distribution(random_device)); });
   }
 
   template<typename T>
@@ -86,12 +83,12 @@ namespace tuvx
   template<typename T>
   inline void Print(const Array1D<T> &x)
   {
-    std::cout << std::endl;
-    for (std::size_t i = 0; i < x.Size(); i++)
+    std::cout << '\n';
+    for (const auto &value : x)
     {
-      std::cout << x[i] << std::endl;
+      std::cout << value << '\n';
     }
-    std::cout << std::endl;
+    std::cout << '\n';
   }
 
   template<typename T>
@@ -114,11 +111,11 @@ namespace tuvx
   template<typename T>
   inline void Print(const TridiagonalMatrix<T> &x)
   {
-    std::cout << "----" << std::endl;
+    std::cout << "----\n";
     Print(x.upper_diagonal_);
     Print(x.main_diagonal_);
     Print(x.lower_diagonal_);
-    std::cout << "----" << std::endl;
+    std::cout << "----\n";
   }
 
 }  // namespace tuvx


### PR DESCRIPTION
A small modernization pass from a survey of the codebase for `std::ranges` / C++20 opportunities.

## Changes (all in `linear_algebra.inl`, host-only utilities)

- `FillRandom(Array1D)`: raw index loop → `std::ranges::generate`
- `Print(Array1D)`: raw index loop → range-based for
- `Print` helpers: `std::endl` → `'\n'` (`performance-avoid-endl`)

Behavior-preserving; full suite 16/16.

## Survey outcome (why this PR is small)

The codebase is already largely modern:
- `std::ranges` is used in **every** host-only algorithm spot (`tabulated_lookup`→`find_if`, `scaled_array`/`scaled_table`→`transform`, regression `Distinct`/`IndexOf`→`find`). There are **zero** non-`ranges` `std::` algorithm calls.
- `std::numbers::pi` is used (no hand-rolled constants); concepts and designated initializers are used throughout.

The remaining raw loops are intentionally **not** `std::ranges`:
1. **Transform weight-array loops** (`factories`/`combinators`/`analytic_forms` over `Array3D`, ~50 loops) — hot paths on policy-backed memory; these belong to the `ForEachRow` bulk-ops API (plan **task 12a**), not host-bound `std::ranges`, which would undermine the future `DeviceArrayPolicy` (GPU) seam.
2. **Solver numeric loops** (Thomas algorithm in `linear_algebra`, `delta_eddington`, `spherical_geometry`) — sequential / data-dependent numeric algorithms that read worse as ranges.
3. **Horner folds / strided fills** — `std::accumulate` wouldn't improve clarity and Horner is idiomatic as a loop.

So the substantive loop modernization that remains is **task 12a** (ForEachRow), which is tracked separately in the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)